### PR TITLE
Adding to faster KeepRunning c++11 loop for rootbenches

### DIFF
--- a/root/interpreter/RunInterpreter.cxx
+++ b/root/interpreter/RunInterpreter.cxx
@@ -13,13 +13,18 @@ static int runTutorial(const std::string& dir, const std::string& filename) {
   }
   std::string rootsys = getenv("ROOTSYS");
   std::string fullpath = rootsys + "/" + dir + "/" + filename;
-  std::string rootInvocation = "root.exe -l -q -b -n -x \"" + fullpath + "\" -e return ";
-  return std::system(rootInvocation.c_str());
+  std::string thisroot = rootsys + "/bin/thisroot.sh";
+  // FIXME: no source in /usr/dash
+  std::string rootInvocation = "source \"" + thisroot + "\" && root.exe -l -q -b -n -x \"" + fullpath + "\" -e return ";
+    return std::system(rootInvocation.c_str());
 }
 
 static void TestTutorial(benchmark::State &state, const char *dir, const char *tutorial) {
-   while (state.KeepRunning())
+  // size_t peakSize = 0;
+  for(auto _ : state){
       runTutorial(dir, tutorial);
+   }
+  // state.counters["PeakRSS"] = peakSize;
 }
 
 BENCHMARK_CAPTURE(TestTutorial, Test_hsimple, "tutorials/", "hsimple.C")->Unit(benchmark::kMicrosecond);

--- a/root/io/io/TBufferMergerBenchmarks.cxx
+++ b/root/io/io/TBufferMergerBenchmarks.cxx
@@ -22,7 +22,7 @@ int GetNumberHardwareThreads()
 static void BM_TBufferFile_CreateEmpty(benchmark::State &state)
 {
    const char *filename = "empty.root";
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       TBufferMerger m(std::unique_ptr<TMemFile>(new TMemFile(filename, "RECREATE")));
    }
 }
@@ -40,7 +40,7 @@ static void BM_TBufferFile_GetFile(benchmark::State &state)
       // when we benchmark IO.
       Merger = new TBufferMerger(std::unique_ptr<TMemFile>(new TMemFile("virtual_file.root", "RECREATE")));
    }
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       // Run the test as normal.
       auto myFile = Merger->GetFile();
    }
@@ -94,7 +94,7 @@ static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
       Merger = new TBufferMerger(std::unique_ptr<TMemFile>(new TMemFile("virtual_file.root", "RECREATE")));
    }
    int flush = state.range(0);
-   while (state.KeepRunning())
+   for (auto _ : state)
       FillTreeWithRandomData(*Merger, flush);
    auto size = Merger->GetFile()->GetSize();
    std::stringstream ss;

--- a/root/math/genvector/Transform3DBenchmarks.cxx
+++ b/root/math/genvector/Transform3DBenchmarks.cxx
@@ -23,7 +23,7 @@ Point<T> sp6(p_x(ggen), p_y(ggen), p_z(ggen));
 template <typename T>
 static void BM_Transform3D(benchmark::State &state)
 {
-   while (state.KeepRunning()) {
+   for (auto _ : state){
       ROOT::Math::Impl::Transform3D<T> st(sp1, sp2, sp3, sp4, sp5, sp6);
       st.Translation();
    }
@@ -38,7 +38,7 @@ using Point = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Mat
 template <typename T>
 static void BM_Point3D(benchmark::State &state)
 {
-   while (state.KeepRunning())
+   for (auto _ : state)
       Point<T> sp1, sp2, sp3, sp4, sp5, sp6;
 }
 
@@ -48,7 +48,7 @@ BENCHMARK_TEMPLATE(BM_Point3D, ROOT::Double_v)->Range(8, 8 << 10)->Complexity(be
 template <typename T>
 static void BM_Point3D_Gen(benchmark::State &state)
 {
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       Point<T> sp1(p_x(ggen), p_y(ggen), p_z(ggen));
    }
 }
@@ -59,7 +59,7 @@ template <typename T>
 static void BM_Plane3D(benchmark::State &state)
 {
    const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       Plane<T> sc_plane(a, b, c, d);
    }
 }
@@ -71,7 +71,7 @@ template <typename T>
 static void BM_Plane3D_Hessian(benchmark::State &state)
 {
    const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       Plane<T> sc_plane(a, b, c, d);
       sc_plane.HesseDistance();
    }
@@ -83,7 +83,7 @@ template <typename T>
 static void BM_Plane3D_Normal(benchmark::State &state)
 {
    const double a(p0(ggen)), b(p1(ggen)), c(p2(ggen)), d(p3(ggen));
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       Plane<T> sc_plane(a, b, c, d);
       sc_plane.Normal();
    }

--- a/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
+++ b/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
@@ -182,7 +182,7 @@ static void BM_RooFit_BinnedTestMigrad(benchmark::State &state)
    m.setStrategy(0);
    m.setProfile(0);
    m.setLogFile("benchmigradlog");
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       m.migrad();
    }
    delete data;
@@ -219,7 +219,7 @@ static void BM_RooFit_BinnedTestMigrad_NChannel(benchmark::State &state)
    m.setStrategy(0);
    m.setProfile(0);
    m.setLogFile("benchmigradnchanellog");
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       m.migrad();
    }
    delete data;
@@ -257,7 +257,7 @@ static void BM_RooFit_BinnedTestHesse(benchmark::State &state)
    m.setProfile(0);
    m.setLogFile("benchhesselog");
    m.migrad();
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       m.hesse();
    }
    delete data;
@@ -293,7 +293,7 @@ static void BM_RooFit_BinnedTestMinos(benchmark::State &state)
    m.setProfile(0);
    m.setLogFile("benchminoslog");
    m.migrad();
-   while (state.KeepRunning()) {
+   for (auto _ : state) {
       m.minos();
    }
    delete data;


### PR DESCRIPTION
Adding to faster KeepRunning c++11 loop for rootbenches and updating ROOTSYS for InterpreterBench (in case it was not correctly setuped before)