### PR TITLE
Add a rootbench config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_MODULE_PATH
   )
 
 include(AddRootBench)
+# Add the path to benchmarking libraries.
+include_directories(${CMAKE_SOURCE_DIR}/include)
 
 # You need first to tell CMake where to find the ROOT installation. This can either be the 
 # final ROOT installation or a local build directory. In both cases it is using

--- a/include/rootbench/RBConfig.h
+++ b/include/rootbench/RBConfig.h
@@ -1,0 +1,16 @@
+
+#include <stdlib.h>
+
+namespace RB {
+  /// Returns a path to temporary file system (preferably in-memory). The path
+  /// is set in the RB_TEMP_FS environment variable.
+  ///
+  ///\returns invalid path if the variable is not set.
+  ///
+  const char* GetTempFs() {
+    if (char* tempfs = std::getenv("RB_TEMP_FS"))
+      return tempfs;
+    // Instead of aborting return something that cannot be a path.
+    return "@@@ Please set the RB_TEMP_FS env variable @@@";
+  }
+}


### PR DESCRIPTION
The purpose of the file is to simplify the benchmarking code by
using the predefined settings.