### PR TITLE
Add PyROOT to benchmarks

### DIFF
--- a/root/CMakeLists.txt
+++ b/root/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(math)
 add_subdirectory(io)
 add_subdirectory(interpreter)
+add_subdirectory(pyroot)
 if (ROOT_roofit_FOUND AND ROOT_xml_FOUND)
   add_subdirectory(roofit)
 endif()

--- a/root/pyroot/CMakeLists.txt
+++ b/root/pyroot/CMakeLists.txt
@@ -1,0 +1,3 @@
+RB_ADD_GBENCHMARK(PyROOTBenchmarks
+  RunPyROOT.cxx
+  LABEL short)

--- a/root/pyroot/PyROOTTest.h
+++ b/root/pyroot/PyROOTTest.h
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <cstdlib>
+#include <string>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+#include <unistd.h>
+
+#include "benchmark/benchmark.h"
+
+#include <chrono>
+
+static int runTutorial(const std::string& dir, const std::string& filename) {
+  if (getenv("ROOTSYS") == nullptr) {
+    std::cerr << "Couldn't find ROOTSYS environment variable!\n";
+    exit(1);
+  }
+  std::string rootsys = getenv("ROOTSYS");
+  std::string fullpath = rootsys + "/" + dir + "/" + filename;
+  std::string rootInvocation = "root -l -b -q -e 'TPython::Exec(\" exec( open(\"" + fullpath + "\").read())\")'";
+    return std::system(rootInvocation.c_str());
+}
+
+static void TestTutorial(benchmark::State &state, const char *dir, const char *tutorial) {
+  int peakSize = 0;
+  for(auto _ : state){
+      auto start = std::chrono::high_resolution_clock::now();
+      runTutorial(dir, tutorial);
+      auto end   = std::chrono::high_resolution_clock::now();
+      auto elapsed_seconds =
+      std::chrono::duration_cast<std::chrono::duration<double>>(
+        end - start);
+      state.SetIterationTime(elapsed_seconds.count());
+   }
+   state.counters.insert({{"RSS", peakSize}});
+}

--- a/root/pyroot/RunPyROOT.cxx
+++ b/root/pyroot/RunPyROOT.cxx
@@ -1,0 +1,23 @@
+#include "PyROOTTest.h"
+
+#include "benchmark/benchmark.h"
+
+BENCHMARK_CAPTURE(TestTutorial, Test_hsimple, "tutorials/pyroot/", "hsimple.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_framework, "tutorials/pyroot/", "framework.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_hsum, "tutorials/pyroot/", "hsum.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_formula1, "tutorials/pyroot/", "formula1.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_fillrandom, "tutorials/pyroot/", "fillrandom.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_fit1, "tutorials/pyroot/", "fit1.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_h1draw, "tutorials/pyroot/", "h1draw.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_graph, "tutorials/pyroot/", "graph.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_gerrors, "tutorials/pyroot/", "gerrors.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_tornado, "tutorials/pyroot/", "tornado.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_surfaces, "tutorials/pyroot/", "surfaces.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_zdemo, "tutorials/pyroot/", "zdemo.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_geometry, "tutorials/pyroot/", "geometry.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_na49view, "tutorials/pyroot/", "na49view.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_file, "tutorials/pyroot/", "file.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_ntuple1, "tutorials/pyroot/", "ntuple1.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+BENCHMARK_CAPTURE(TestTutorial, Test_rootmarks, "tutorials/pyroot/", "rootmarks.py")->Unit(benchmark::kMicrosecond)->UseManualTime();
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This patch allows us to benchmark pyroot by executing ctest and emit csv
files for plotting.