### PR TITLE
[TMVA] Exclude TMVA cross-validation benchmark if TMVA not enabled

### DIFF
--- a/root/tmva/tmva/CMakeLists.txt
+++ b/root/tmva/tmva/CMakeLists.txt
@@ -1,7 +1,9 @@
-RB_ADD_GBENCHMARK(CrossValidationBenchmarks
-  CrossValidationBenchmarks.cxx
-  LABEL short
-  LIBRARIES Core Tree MathCore TMVA)
+if(ROOT_tmva_FOUND)
+   RB_ADD_GBENCHMARK(CrossValidationBenchmarks
+      CrossValidationBenchmarks.cxx
+      LABEL short
+      LIBRARIES Core Tree MathCore TMVA)
+endif()
 
 if(ROOT_tmva_FOUND AND ROOT_tmva-cpu_FOUND AND ROOT_imt_FOUND)
    RB_ADD_GBENCHMARK(ConvNetCpuBenchmarks


### PR DESCRIPTION
Currently breaks with `-Dtmva=OFF`!