### PR TITLE
Updated the README.md for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ ROOTBench can be built standalone and as part of ROOT. If you want to enable ROO
 
 ### Building ROOTBench standalone
 ROOTBench should be able to find ROOT at configuration time. Make sure you ran `source $ROOTSYS/bin/thisroot.sh`.
+
+> **:warning: This Project uses submodules!**  
+> **Either use `git clone --recursive` or run `git submodule update --init -- recursive` after cloning the repository, otherwise the build will fail!**
 ```bash
 git clone https://github.com/root-project/rootbench.git
 mkdir build


### PR DESCRIPTION
This repository contains subdirectories so whenever we git clone the repository normally it will show error in the build process. "git submodule update --init --recursive " after cloning the repo, will resolve this issue.