### PR TITLE
Add compression benchmarks for LHCb/NanoAOD/ATLAS files

### DIFF
--- a/root/io/io/CMakeLists.txt
+++ b/root/io/io/CMakeLists.txt
@@ -14,4 +14,10 @@ if(rootbench-datafiles)
     LABEL short
     LIBRARIES Core RIO
     DOWNLOAD_DATAFILES Event0-sample.root)
+  
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_LHCb
+    TFile_LHCb_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
 endif()

--- a/root/io/io/CMakeLists.txt
+++ b/root/io/io/CMakeLists.txt
@@ -20,4 +20,10 @@ if(rootbench-datafiles)
     LABEL short
     LIBRARIES Core RIO
     DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
+  
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_NanoAOD
+    TFile_NanoAOD_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root)
 endif()

--- a/root/io/io/CMakeLists.txt
+++ b/root/io/io/CMakeLists.txt
@@ -26,4 +26,10 @@ if(rootbench-datafiles)
     LABEL short
     LIBRARIES Core RIO
     DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root)
+  
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_ATLAS
+    TFile_ATLAS_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES gg_data-zstd.root)
 endif()

--- a/root/io/io/TFile_ATLAS_Benchmark.cxx
+++ b/root/io/io/TFile_ATLAS_Benchmark.cxx
@@ -1,0 +1,129 @@
+#include "TFile.h"
+#include "TTree.h"
+
+#include "benchmark/benchmark.h"
+#include "rootbench/RBConfig.h"
+
+#include <map>
+
+static std::string GetAlgoName(int algo) {
+    std::map<int, std::string> algoName = {
+        {1, "zlib"},
+        {2, "lzma"},
+        {4, "lz4"},
+        {5, "zstd"}
+    };
+
+    if (algoName.find(algo) != algoName.end())
+        return algoName[algo];
+    else
+        return "error";
+}
+
+static void BM_ATLAS_Compress(benchmark::State &state, int algo) {
+    TFile *oldfile = new TFile((RB::GetDataDir() + "/gg_data-zstd.root").c_str());
+    TTree *oldtree = (TTree*)oldfile->Get("mini");
+
+    int comp_level = state.range(0);
+    std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
+
+    for (auto _ : state) {
+        state.PauseTiming();
+
+        TFile *newfile = new TFile(filename.c_str(), "recreate");
+        TTree *newtree = oldtree->CloneTree();
+        newfile->SetCompressionAlgorithm(algo);
+        newfile->SetCompressionLevel(comp_level);
+
+        state.ResumeTiming();
+        newfile->Write();
+        state.PauseTiming();
+
+        state.counters["comp_size"] = newfile->GetBytesWritten();
+        newfile->Close();
+
+        state.ResumeTiming();
+    }
+}
+
+static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
+    int comp_level = state.range(0);
+
+    std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
+    for (auto _ : state) {
+        TFile *hfile = new TFile(filename.c_str());
+        TTree *tree = (TTree*)hfile->Get("mini");
+
+        Int_t nevent = (Int_t)tree->GetEntries();
+
+        Int_t nb = 0;
+        Int_t ev;
+
+        for (ev = 0; ev < nevent; ev++) {
+            nb += tree->GetEntry(ev);
+        }
+    }
+}
+
+static void BM_ATLAS_Compress_ZLIB(benchmark::State &state) {
+    BM_ATLAS_Compress(state, 1);
+}
+static void BM_ATLAS_Compress_LZMA(benchmark::State &state) {
+    BM_ATLAS_Compress(state, 2);
+}
+static void BM_ATLAS_Compress_LZ4(benchmark::State &state) {
+    BM_ATLAS_Compress(state, 4);
+}
+static void BM_ATLAS_Compress_ZSTD(benchmark::State &state) {
+    BM_ATLAS_Compress(state, 5);
+}
+
+static void BM_ATLAS_Decompress_ZLIB(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 1);
+}
+static void BM_ATLAS_Decompress_LZMA(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 2);
+}
+static void BM_ATLAS_Decompress_LZ4(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 4);
+}
+static void BM_ATLAS_Decompress_ZSTD(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 5);
+}
+
+
+BENCHMARK(BM_ATLAS_Compress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Compress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Compress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Compress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK(BM_ATLAS_Decompress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Decompress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Decompress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_ATLAS_Decompress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK_MAIN(); 

--- a/root/io/io/TFile_LHCb_Benchmarks.cxx
+++ b/root/io/io/TFile_LHCb_Benchmarks.cxx
@@ -1,0 +1,145 @@
+#include "TFile.h"
+#include "TTree.h"
+
+#include "benchmark/benchmark.h"
+#include "rootbench/RBConfig.h"
+
+#include <map>
+
+static std::string GetAlgoName(int algo) {
+    std::map<int, std::string> algoName = {
+        {1, "zlib"},
+        {2, "lzma"},
+        {4, "lz4"},
+        {5, "zstd"}
+    };
+
+    if (algoName.find(algo) != algoName.end())
+        return algoName[algo];
+    else
+        return "error";
+}
+
+static void BM_LHCb_Compress(benchmark::State &state, int algo) {
+    TFile *oldfile = new TFile((RB::GetDataDir() + "/lhcb_B2ppKK2011_md_noPIDstrip.root").c_str());
+    TTree *oldtree1 = (TTree*)oldfile->Get("TupleB2ppKK/DecayTree");
+    TTree *oldtree2 = (TTree*)oldfile->Get("TupleB2ppKPi/DecayTree");
+    TTree *oldtree3 = (TTree*)oldfile->Get("TupleB2ppPiPi/DecayTree");
+
+    int comp_level = state.range(0);
+    std::string filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
+
+    for (auto _ : state) {
+        state.PauseTiming();
+
+        TFile *newfile = new TFile(filename.c_str(), "recreate");
+        TTree *newtree1 = oldtree1->CloneTree();
+        TTree *newtree2 = oldtree2->CloneTree();
+        TTree *newtree3 = oldtree3->CloneTree();
+        newfile->SetCompressionAlgorithm(algo);
+        newfile->SetCompressionLevel(comp_level);
+
+        state.ResumeTiming();
+        newfile->Write();
+        state.PauseTiming();
+
+        state.counters["comp_size"] = newfile->GetBytesWritten();
+        newfile->Close();
+
+        state.ResumeTiming();
+    }
+}
+
+static void BM_LHCb_Decompress(benchmark::State &state, int algo) {
+    int comp_level = state.range(0);
+
+    std::string filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
+    for (auto _ : state) {
+        TFile *hfile = new TFile(filename.c_str());
+        TTree *tree1 = (TTree*)hfile->Get("TupleB2ppKK/DecayTree");
+        TTree *tree2 = (TTree*)hfile->Get("TupleB2ppKPi/DecayTree");
+        TTree *tree3 = (TTree*)hfile->Get("TupleB2ppPiPi/DecayTree");
+
+        Int_t nevent1 = (Int_t)tree1->GetEntries();
+        Int_t nevent2 = (Int_t)tree2->GetEntries();
+        Int_t nevent3 = (Int_t)tree3->GetEntries();
+
+        Int_t nb = 0;
+        Int_t ev;
+
+        for (ev = 0; ev < nevent1; ev++) {
+            nb += tree1->GetEntry(ev);
+        }
+
+        for (ev = 0; ev < nevent2; ev++) {
+            nb += tree2->GetEntry(ev);
+        }
+
+        for (ev = 0; ev < nevent3; ev++) {
+            nb += tree3->GetEntry(ev);
+        }
+    }
+}
+
+static void BM_LHCb_Compress_ZLIB(benchmark::State &state) {
+    BM_LHCb_Compress(state, 1);
+}
+static void BM_LHCb_Compress_LZMA(benchmark::State &state) {
+    BM_LHCb_Compress(state, 2);
+}
+static void BM_LHCb_Compress_LZ4(benchmark::State &state) {
+    BM_LHCb_Compress(state, 4);
+}
+static void BM_LHCb_Compress_ZSTD(benchmark::State &state) {
+    BM_LHCb_Compress(state, 5);
+}
+
+static void BM_LHCb_Decompress_ZLIB(benchmark::State &state) {
+    BM_LHCb_Decompress(state, 1);
+}
+static void BM_LHCb_Decompress_LZMA(benchmark::State &state) {
+    BM_LHCb_Decompress(state, 2);
+}
+static void BM_LHCb_Decompress_LZ4(benchmark::State &state) {
+    BM_LHCb_Decompress(state, 4);
+}
+static void BM_LHCb_Decompress_ZSTD(benchmark::State &state) {
+    BM_LHCb_Decompress(state, 5);
+}
+
+
+BENCHMARK(BM_LHCb_Compress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Compress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Compress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Compress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK(BM_LHCb_Decompress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Decompress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Decompress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_LHCb_Decompress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK_MAIN(); 

--- a/root/io/io/TFile_NanoAOD_Benchmarks.cxx
+++ b/root/io/io/TFile_NanoAOD_Benchmarks.cxx
@@ -1,0 +1,129 @@
+#include "TFile.h"
+#include "TTree.h"
+
+#include "benchmark/benchmark.h"
+#include "rootbench/RBConfig.h"
+
+#include <map>
+
+static std::string GetAlgoName(int algo) {
+    std::map<int, std::string> algoName = {
+        {1, "zlib"},
+        {2, "lzma"},
+        {4, "lz4"},
+        {5, "zstd"}
+    };
+
+    if (algoName.find(algo) != algoName.end())
+        return algoName[algo];
+    else
+        return "error";
+}
+
+static void BM_NanoAOD_Compress(benchmark::State &state, int algo) {
+    TFile *oldfile = new TFile((RB::GetDataDir() + "/Run2012B_DoubleMuParked.root").c_str());
+    TTree *oldtree = (TTree*)oldfile->Get("Events");
+
+    int comp_level = state.range(0);
+    std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
+
+    for (auto _ : state) {
+        state.PauseTiming();
+
+        TFile *newfile = new TFile(filename.c_str(), "recreate");
+        TTree *newtree = oldtree->CloneTree();
+        newfile->SetCompressionAlgorithm(algo);
+        newfile->SetCompressionLevel(comp_level);
+
+        state.ResumeTiming();
+        newfile->Write();
+        state.PauseTiming();
+
+        state.counters["comp_size"] = newfile->GetBytesWritten();
+        newfile->Close();
+
+        state.ResumeTiming();
+    }
+}
+
+static void BM_NanoAOD_Decompress(benchmark::State &state, int algo) {
+    int comp_level = state.range(0);
+
+    std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
+    for (auto _ : state) {
+        TFile *hfile = new TFile(filename.c_str());
+        TTree *tree = (TTree*)hfile->Get("Events");
+
+        Int_t nevent = (Int_t)tree->GetEntries();
+
+        Int_t nb = 0;
+        Int_t ev;
+
+        for (ev = 0; ev < nevent; ev++) {
+            nb += tree->GetEntry(ev);
+        }
+    }
+}
+
+static void BM_NanoAOD_Compress_ZLIB(benchmark::State &state) {
+    BM_NanoAOD_Compress(state, 1);
+}
+static void BM_NanoAOD_Compress_LZMA(benchmark::State &state) {
+    BM_NanoAOD_Compress(state, 2);
+}
+static void BM_NanoAOD_Compress_LZ4(benchmark::State &state) {
+    BM_NanoAOD_Compress(state, 4);
+}
+static void BM_NanoAOD_Compress_ZSTD(benchmark::State &state) {
+    BM_NanoAOD_Compress(state, 5);
+}
+
+static void BM_NanoAOD_Decompress_ZLIB(benchmark::State &state) {
+    BM_NanoAOD_Decompress(state, 1);
+}
+static void BM_NanoAOD_Decompress_LZMA(benchmark::State &state) {
+    BM_NanoAOD_Decompress(state, 2);
+}
+static void BM_NanoAOD_Decompress_LZ4(benchmark::State &state) {
+    BM_NanoAOD_Decompress(state, 4);
+}
+static void BM_NanoAOD_Decompress_ZSTD(benchmark::State &state) {
+    BM_NanoAOD_Decompress(state, 5);
+}
+
+
+BENCHMARK(BM_NanoAOD_Compress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Compress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Compress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Compress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK(BM_NanoAOD_Decompress_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Decompress_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Decompress_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+BENCHMARK(BM_NanoAOD_Decompress_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(5);
+
+
+BENCHMARK_MAIN(); 


### PR DESCRIPTION
I add new compression/decompression benchmarks for files below:

- `lhcb_B2ppKK2011_md_noPIDstrip.root`
- `Run2012B_DoubleMuParked.root`
- `gg_data-zstd.root`