### PR TITLE
Refactor df102* benchmarks

### DIFF
--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -7,7 +7,7 @@ RB_ADD_GBENCHMARK(RDFBenchmarks
 if(rootbench-datafiles)
     RB_ADD_GBENCHMARK(gbenchmark-df102_NanoAODDimuonAnalysis
         df102_NanoAODDimuonAnalysis.C
-        DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root Run2012C_DoubleMuParked.root
+        DOWNLOAD_DATAFILES Run2012BC_DoubleMuParked_Muons.root
         LABEL long
         LIBRARIES Core Hist Imt RIO Tree TreePlayer ROOTDataFrame ROOTVecOps Gpad Graf)
 
@@ -25,7 +25,7 @@ endif()
 if(rootbench-datafiles)
     RB_ADD_PYTESTBENCHMARK(pytest-df102_NanoAODDimuonAnalysis
         df102_NanoAODDimuonAnalysis.py
-        DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root Run2012C_DoubleMuParked.root
+        DOWNLOAD_DATAFILES Run2012BC_DoubleMuParked_Muons.root
         LABEL long)
 
     RB_ADD_PYTESTBENCHMARK(pytest-df104_HiggsToTwoPhotons

--- a/root/tree/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/root/tree/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -17,8 +17,7 @@
 
 using namespace ROOT::VecOps;
 
-static const std::vector<std::string> local_files = {RB::GetDataDir() + "/Run2012B_DoubleMuParked.root",
-                                                     RB::GetDataDir() + "/Run2012C_DoubleMuParked.root"};
+static const std::vector<std::string> local_files = {RB::GetDataDir() + "/Run2012BC_DoubleMuParked_Muons.root"};
 
 void payload(const std::vector<std::string>& files, unsigned int nthreads)
 {

--- a/root/tree/dataframe/df102_NanoAODDimuonAnalysis.py
+++ b/root/tree/dataframe/df102_NanoAODDimuonAnalysis.py
@@ -6,14 +6,12 @@ import pytest
 import os
 
 
-files = ROOT.std.vector("string")(2)
-files[0] = os.path.join(os.environ["RB_DATASETDIR"], "Run2012B_DoubleMuParked.root")
-files[1] = os.path.join(os.environ["RB_DATASETDIR"], "Run2012C_DoubleMuParked.root")
+files = os.path.join(os.environ["RB_DATASETDIR"], "Run2012BC_DoubleMuParked_Muons.root")
 
-def payload(files, enable_imt):
+def payload(files, nthreads):
     # Enable multi-threading
-    if enable_imt:
-        ROOT.ROOT.EnableImplicitMT()
+    if nthreads > 1:
+        ROOT.ROOT.EnableImplicitMT(nthreads)
     else:
         ROOT.ROOT.DisableImplicitMT()
 
@@ -61,8 +59,8 @@ def payload(files, enable_imt):
 
 
 def test_df102_NanoAODDimuonAnalysis_imt(benchmark):
-    benchmark.pedantic(payload, kwargs={'files': files, 'enable_imt': True}, iterations=1, rounds=1)
+    benchmark.pedantic(payload, kwargs={'files': files, 'nthreads': 8}, iterations=1, rounds=1)
 
 
 def test_df102_NanoAODDimuonAnalysis_noimt(benchmark):
-    benchmark.pedantic(payload, kwargs={'files': files, 'enable_imt': False}, iterations=1, rounds=1)
+    benchmark.pedantic(payload, kwargs={'files': files, 'nthreads': 1}, iterations=1, rounds=1)


### PR DESCRIPTION
* Use nthreads argument for df102*.py benchmarks instead of
  a flag to enable/disable imt
* Use smaller file with only the muon collections to improve reliability
  in the CI and for faster download of the data