### PR TITLE
Add missing include to TTreeBenchmarks.cxx

### DIFF
--- a/root/tree/tree/TTreeBenchmarks.cxx
+++ b/root/tree/tree/TTreeBenchmarks.cxx
@@ -1,5 +1,6 @@
 #include <TFile.h>
 #include <TSystem.h>
+#include <TBranch.h>
 #include <TTree.h>
 
 #include <benchmark/benchmark.h>


### PR DESCRIPTION
Problem is only visible when compiling with R__LESS_INCLUDES