### PR TITLE
Fix unused variable warning

### DIFF
--- a/root/io/io/TFile_CompressionBenchmarks_MainEvent.cxx
+++ b/root/io/io/TFile_CompressionBenchmarks_MainEvent.cxx
@@ -55,7 +55,6 @@ static void BM_MainEvent_Decompress(benchmark::State &state, int algo) {
       TFile *hfile = new TFile(filename.c_str());
       TTree *tree = (TTree*)hfile->Get("T");
       (void)tree; // silence unused variable warnings. ROOT internals use this tree.
-      TBranch *branch = tree->GetBranch("event");
 
       Int_t nevent = (Int_t)tree->GetEntries();
 


### PR DESCRIPTION
This `branch` variable really seems unused and I'm not aware of side-effects of `GetBranch` that we might be interested in here.
But I might very well be wrong. @oshadura are you the maintainer of these benchmarks?