### PR TITLE
Fix compression benchmarks

### DIFF
--- a/root/io/io/CMakeLists.txt
+++ b/root/io/io/CMakeLists.txt
@@ -15,22 +15,21 @@ if(rootbench-datafiles)
     LIBRARIES Core RIO
     DOWNLOAD_DATAFILES Event0-sample.root)
 
-  # FIXME: too long benchmarks, needs to be optimised
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_LHCb
-  #  TFile_LHCb_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_LHCb
+    TFile_LHCb_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
 
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_NanoAOD
-  #  TFile_NanoAOD_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_NanoAOD
+    TFile_NanoAOD_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES Run2012B_DoubleElectron.root)
 
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_ATLAS
-  #  TFile_ATLAS_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES gg_data-zstd.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_ATLAS
+    TFile_ATLAS_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO
+    DOWNLOAD_DATAFILES atlasopendata_mc_117050.ttbar_lep.root atlasopendata_DataMuons.root)
 endif()

--- a/root/io/io/TFile_ATLAS_Benchmarks.cxx
+++ b/root/io/io/TFile_ATLAS_Benchmarks.cxx
@@ -21,11 +21,11 @@ static std::string GetAlgoName(int algo) {
         return "error";
 }
 
-static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
+static void BM_ATLAS_Decompress(benchmark::State &state, int algo, std::string filename) {
 
     int comp_level = state.range(0);
     std::string comp_setting = std::to_string(algo * 100 + comp_level);
-    std::string old_filename = (RB::GetDataDir() + "/gg_data-zstd.root").c_str();
+    std::string old_filename = (RB::GetDataDir() + "/" + filename + ".root").c_str();
     std::string new_filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
 
     gSystem->Exec(("hadd -v 0 -f" + comp_setting + " " + new_filename + " " + old_filename).c_str());
@@ -56,35 +56,64 @@ static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
 }
 
 
-static void BM_ATLAS_Decompress_ZLIB(benchmark::State &state) {
-    BM_ATLAS_Decompress(state, 1);
+static void BM_ATLAS_Decompress_Real_ZLIB(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 1, "atlasopendata_DataMuons");
 }
-static void BM_ATLAS_Decompress_LZMA(benchmark::State &state) {
-    BM_ATLAS_Decompress(state, 2);
+static void BM_ATLAS_Decompress_Real_LZMA(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 2, "atlasopendata_DataMuons");
 }
-static void BM_ATLAS_Decompress_LZ4(benchmark::State &state) {
-    BM_ATLAS_Decompress(state, 4);
+static void BM_ATLAS_Decompress_Real_LZ4(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 4, "atlasopendata_DataMuons");
 }
-static void BM_ATLAS_Decompress_ZSTD(benchmark::State &state) {
-    BM_ATLAS_Decompress(state, 5);
+static void BM_ATLAS_Decompress_Real_ZSTD(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 5, "atlasopendata_DataMuons");
 }
 
-
-BENCHMARK(BM_ATLAS_Decompress_ZLIB)
+BENCHMARK(BM_ATLAS_Decompress_Real_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
-BENCHMARK(BM_ATLAS_Decompress_LZMA)
+BENCHMARK(BM_ATLAS_Decompress_Real_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
-BENCHMARK(BM_ATLAS_Decompress_LZ4)
+BENCHMARK(BM_ATLAS_Decompress_Real_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
-BENCHMARK(BM_ATLAS_Decompress_ZSTD)
+BENCHMARK(BM_ATLAS_Decompress_Real_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
+
+
+static void BM_ATLAS_Decompress_MC_ZLIB(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 1, "atlasopendata_mc_117050.ttbar_lep");
+}
+static void BM_ATLAS_Decompress_MC_LZMA(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 2, "atlasopendata_mc_117050.ttbar_lep");
+}
+static void BM_ATLAS_Decompress_MC_LZ4(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 4, "atlasopendata_mc_117050.ttbar_lep");
+}
+static void BM_ATLAS_Decompress_MC_ZSTD(benchmark::State &state) {
+    BM_ATLAS_Decompress(state, 5, "atlasopendata_mc_117050.ttbar_lep");
+}
+
+BENCHMARK(BM_ATLAS_Decompress_MC_ZLIB)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(3);
+
+BENCHMARK(BM_ATLAS_Decompress_MC_LZMA)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(3);
+
+BENCHMARK(BM_ATLAS_Decompress_MC_LZ4)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(3);
+
+BENCHMARK(BM_ATLAS_Decompress_MC_ZSTD)
+->Arg(1)->Arg(6)->Arg(9)
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 
 BENCHMARK_MAIN();

--- a/root/io/io/TFile_ATLAS_Benchmarks.cxx
+++ b/root/io/io/TFile_ATLAS_Benchmarks.cxx
@@ -1,5 +1,6 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TSystem.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
@@ -20,38 +21,22 @@ static std::string GetAlgoName(int algo) {
         return "error";
 }
 
-static void BM_ATLAS_Compress(benchmark::State &state, int algo) {
-    TFile *oldfile = new TFile((RB::GetDataDir() + "/gg_data-zstd.root").c_str());
-    TTree *oldtree = (TTree*)oldfile->Get("mini");
-
-    int comp_level = state.range(0);
-    std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
-
-    for (auto _ : state) {
-        state.PauseTiming();
-
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree = oldtree->CloneTree();
-        newfile->SetCompressionAlgorithm(algo);
-        newfile->SetCompressionLevel(comp_level);
-
-        state.ResumeTiming();
-        newfile->Write();
-        state.PauseTiming();
-
-        state.counters["comp_size"] = newfile->GetBytesWritten();
-        newfile->Close();
-
-        state.ResumeTiming();
-    }
-}
-
 static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
-    int comp_level = state.range(0);
 
-    std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
+    int comp_level = state.range(0);
+    std::string comp_setting = std::to_string(algo * 100 + comp_level);
+    std::string old_filename = (RB::GetDataDir() + "/gg_data-zstd.root").c_str();
+    std::string new_filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
+
+    gSystem->Exec(("hadd -v 0 -f" + comp_setting + " " + new_filename + " " + old_filename).c_str());
+
+    TFile *newfile = new TFile(new_filename.c_str());
+    state.counters["comp_size"] = newfile->GetSize();
+    newfile->Close();
+
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
+
+        TFile *hfile = new TFile(new_filename.c_str());
         TTree *tree = (TTree*)hfile->Get("mini");
 
         Int_t nevent = (Int_t)tree->GetEntries();
@@ -62,21 +47,14 @@ static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
         for (ev = 0; ev < nevent; ev++) {
             nb += tree->GetEntry(ev);
         }
+
+        hfile->Close();
+
     }
+
+    gSystem->Exec(("rm -f " + new_filename).c_str());
 }
 
-static void BM_ATLAS_Compress_ZLIB(benchmark::State &state) {
-    BM_ATLAS_Compress(state, 1);
-}
-static void BM_ATLAS_Compress_LZMA(benchmark::State &state) {
-    BM_ATLAS_Compress(state, 2);
-}
-static void BM_ATLAS_Compress_LZ4(benchmark::State &state) {
-    BM_ATLAS_Compress(state, 4);
-}
-static void BM_ATLAS_Compress_ZSTD(benchmark::State &state) {
-    BM_ATLAS_Compress(state, 5);
-}
 
 static void BM_ATLAS_Decompress_ZLIB(benchmark::State &state) {
     BM_ATLAS_Decompress(state, 1);
@@ -90,23 +68,6 @@ static void BM_ATLAS_Decompress_LZ4(benchmark::State &state) {
 static void BM_ATLAS_Decompress_ZSTD(benchmark::State &state) {
     BM_ATLAS_Decompress(state, 5);
 }
-
-
-BENCHMARK(BM_ATLAS_Compress_ZLIB)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_ATLAS_Compress_LZMA)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_ATLAS_Compress_LZ4)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_ATLAS_Compress_ZSTD)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
 BENCHMARK(BM_ATLAS_Decompress_ZLIB)
@@ -126,4 +87,4 @@ BENCHMARK(BM_ATLAS_Decompress_ZSTD)
 ->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
-BENCHMARK_MAIN(); 
+BENCHMARK_MAIN();

--- a/root/io/io/TFile_LHCb_Benchmarks.cxx
+++ b/root/io/io/TFile_LHCb_Benchmarks.cxx
@@ -84,19 +84,19 @@ static void BM_LHCb_Decompress_ZSTD(benchmark::State &state) {
 
 BENCHMARK(BM_LHCb_Decompress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_LHCb_Decompress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_LHCb_Decompress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_LHCb_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 
 BENCHMARK_MAIN();

--- a/root/io/io/TFile_LHCb_Benchmarks.cxx
+++ b/root/io/io/TFile_LHCb_Benchmarks.cxx
@@ -1,5 +1,6 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TSystem.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
@@ -20,42 +21,22 @@ static std::string GetAlgoName(int algo) {
         return "error";
 }
 
-static void BM_LHCb_Compress(benchmark::State &state, int algo) {
-    TFile *oldfile = new TFile((RB::GetDataDir() + "/lhcb_B2ppKK2011_md_noPIDstrip.root").c_str());
-    TTree *oldtree1 = (TTree*)oldfile->Get("TupleB2ppKK/DecayTree");
-    TTree *oldtree2 = (TTree*)oldfile->Get("TupleB2ppKPi/DecayTree");
-    TTree *oldtree3 = (TTree*)oldfile->Get("TupleB2ppPiPi/DecayTree");
-
-    int comp_level = state.range(0);
-    std::string filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
-
-    for (auto _ : state) {
-        state.PauseTiming();
-
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree1 = oldtree1->CloneTree();
-        TTree *newtree2 = oldtree2->CloneTree();
-        TTree *newtree3 = oldtree3->CloneTree();
-        newfile->SetCompressionAlgorithm(algo);
-        newfile->SetCompressionLevel(comp_level);
-
-        state.ResumeTiming();
-        newfile->Write();
-        state.PauseTiming();
-
-        state.counters["comp_size"] = newfile->GetBytesWritten();
-        newfile->Close();
-
-        state.ResumeTiming();
-    }
-}
-
 static void BM_LHCb_Decompress(benchmark::State &state, int algo) {
-    int comp_level = state.range(0);
 
-    std::string filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
+    int comp_level = state.range(0);
+    std::string comp_setting = std::to_string(algo * 100 + comp_level);
+    std::string old_filename = (RB::GetDataDir() + "/lhcb_B2ppKK2011_md_noPIDstrip.root").c_str();
+    std::string new_filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
+
+    gSystem->Exec(("hadd -v 0 -f" + comp_setting + " " + new_filename + " " + old_filename).c_str());
+
+    TFile *newfile = new TFile(new_filename.c_str());
+    state.counters["comp_size"] = newfile->GetSize();
+    newfile->Close();
+
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
+        
+        TFile *hfile = new TFile(new_filename.c_str());
         TTree *tree1 = (TTree*)hfile->Get("TupleB2ppKK/DecayTree");
         TTree *tree2 = (TTree*)hfile->Get("TupleB2ppKPi/DecayTree");
         TTree *tree3 = (TTree*)hfile->Get("TupleB2ppPiPi/DecayTree");
@@ -78,21 +59,14 @@ static void BM_LHCb_Decompress(benchmark::State &state, int algo) {
         for (ev = 0; ev < nevent3; ev++) {
             nb += tree3->GetEntry(ev);
         }
+
+        hfile->Close();
+
     }
+
+    gSystem->Exec(("rm -f " + new_filename).c_str());
 }
 
-static void BM_LHCb_Compress_ZLIB(benchmark::State &state) {
-    BM_LHCb_Compress(state, 1);
-}
-static void BM_LHCb_Compress_LZMA(benchmark::State &state) {
-    BM_LHCb_Compress(state, 2);
-}
-static void BM_LHCb_Compress_LZ4(benchmark::State &state) {
-    BM_LHCb_Compress(state, 4);
-}
-static void BM_LHCb_Compress_ZSTD(benchmark::State &state) {
-    BM_LHCb_Compress(state, 5);
-}
 
 static void BM_LHCb_Decompress_ZLIB(benchmark::State &state) {
     BM_LHCb_Decompress(state, 1);
@@ -106,23 +80,6 @@ static void BM_LHCb_Decompress_LZ4(benchmark::State &state) {
 static void BM_LHCb_Decompress_ZSTD(benchmark::State &state) {
     BM_LHCb_Decompress(state, 5);
 }
-
-
-BENCHMARK(BM_LHCb_Compress_ZLIB)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_LHCb_Compress_LZMA)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_LHCb_Compress_LZ4)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_LHCb_Compress_ZSTD)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
 BENCHMARK(BM_LHCb_Decompress_ZLIB)
@@ -142,4 +99,4 @@ BENCHMARK(BM_LHCb_Decompress_ZSTD)
 ->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
-BENCHMARK_MAIN(); 
+BENCHMARK_MAIN();

--- a/root/io/io/TFile_NanoAOD_Benchmarks.cxx
+++ b/root/io/io/TFile_NanoAOD_Benchmarks.cxx
@@ -25,7 +25,7 @@ static void BM_NanoAOD_Decompress(benchmark::State &state, int algo) {
 
     int comp_level = state.range(0);
     std::string comp_setting = std::to_string(algo * 100 + comp_level);
-    std::string old_filename = (RB::GetDataDir() + "/Run2012B_DoubleMuParked.root").c_str();
+    std::string old_filename = (RB::GetDataDir() + "/Run2012B_DoubleElectron.root").c_str();
     std::string new_filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
 
     gSystem->Exec(("hadd -v 0 -f" + comp_setting + " " + new_filename + " " + old_filename).c_str());
@@ -72,19 +72,19 @@ static void BM_NanoAOD_Decompress_ZSTD(benchmark::State &state) {
 
 BENCHMARK(BM_NanoAOD_Decompress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_NanoAOD_Decompress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_NanoAOD_Decompress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 BENCHMARK(BM_NanoAOD_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(3);
 
 
 BENCHMARK_MAIN();

--- a/root/io/io/TFile_NanoAOD_Benchmarks.cxx
+++ b/root/io/io/TFile_NanoAOD_Benchmarks.cxx
@@ -1,5 +1,6 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TSystem.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
@@ -20,38 +21,22 @@ static std::string GetAlgoName(int algo) {
         return "error";
 }
 
-static void BM_NanoAOD_Compress(benchmark::State &state, int algo) {
-    TFile *oldfile = new TFile((RB::GetDataDir() + "/Run2012B_DoubleMuParked.root").c_str());
-    TTree *oldtree = (TTree*)oldfile->Get("Events");
-
-    int comp_level = state.range(0);
-    std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
-
-    for (auto _ : state) {
-        state.PauseTiming();
-
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree = oldtree->CloneTree();
-        newfile->SetCompressionAlgorithm(algo);
-        newfile->SetCompressionLevel(comp_level);
-
-        state.ResumeTiming();
-        newfile->Write();
-        state.PauseTiming();
-
-        state.counters["comp_size"] = newfile->GetBytesWritten();
-        newfile->Close();
-
-        state.ResumeTiming();
-    }
-}
-
 static void BM_NanoAOD_Decompress(benchmark::State &state, int algo) {
-    int comp_level = state.range(0);
 
-    std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
+    int comp_level = state.range(0);
+    std::string comp_setting = std::to_string(algo * 100 + comp_level);
+    std::string old_filename = (RB::GetDataDir() + "/Run2012B_DoubleMuParked.root").c_str();
+    std::string new_filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
+
+    gSystem->Exec(("hadd -v 0 -f" + comp_setting + " " + new_filename + " " + old_filename).c_str());
+
+    TFile *newfile = new TFile(new_filename.c_str());
+    state.counters["comp_size"] = newfile->GetSize();
+    newfile->Close();
+
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
+        
+        TFile *hfile = new TFile(new_filename.c_str());
         TTree *tree = (TTree*)hfile->Get("Events");
 
         Int_t nevent = (Int_t)tree->GetEntries();
@@ -62,21 +47,14 @@ static void BM_NanoAOD_Decompress(benchmark::State &state, int algo) {
         for (ev = 0; ev < nevent; ev++) {
             nb += tree->GetEntry(ev);
         }
+
+        hfile->Close();
+
     }
+
+    gSystem->Exec(("rm -f " + new_filename).c_str());
 }
 
-static void BM_NanoAOD_Compress_ZLIB(benchmark::State &state) {
-    BM_NanoAOD_Compress(state, 1);
-}
-static void BM_NanoAOD_Compress_LZMA(benchmark::State &state) {
-    BM_NanoAOD_Compress(state, 2);
-}
-static void BM_NanoAOD_Compress_LZ4(benchmark::State &state) {
-    BM_NanoAOD_Compress(state, 4);
-}
-static void BM_NanoAOD_Compress_ZSTD(benchmark::State &state) {
-    BM_NanoAOD_Compress(state, 5);
-}
 
 static void BM_NanoAOD_Decompress_ZLIB(benchmark::State &state) {
     BM_NanoAOD_Decompress(state, 1);
@@ -90,23 +68,6 @@ static void BM_NanoAOD_Decompress_LZ4(benchmark::State &state) {
 static void BM_NanoAOD_Decompress_ZSTD(benchmark::State &state) {
     BM_NanoAOD_Decompress(state, 5);
 }
-
-
-BENCHMARK(BM_NanoAOD_Compress_ZLIB)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_NanoAOD_Compress_LZMA)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_NanoAOD_Compress_LZ4)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
-BENCHMARK(BM_NanoAOD_Compress_ZSTD)
-->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
 BENCHMARK(BM_NanoAOD_Decompress_ZLIB)
@@ -126,4 +87,4 @@ BENCHMARK(BM_NanoAOD_Decompress_ZSTD)
 ->Unit(benchmark::kMillisecond)->Iterations(5);
 
 
-BENCHMARK_MAIN(); 
+BENCHMARK_MAIN();


### PR DESCRIPTION
Fixed some problems about LHCb/NanoAOD/ATLAS benchmarks.

To compress properly, 
- Make them use `hadd` command.
- Make them delete files after benchmarking not to suppress storage capacity.

Also, to save time, 
- Change number of iterations from 5 to 3.
- Change file used in NanoAOD BM to smaller one (`Run2012B_DoubleElectron.root`).
- Change file used in ATLAS BM to 2 smaller files: `atlasopendata_mc_117050.ttbar_lep.root` (Monte Carlo data) and `atlasopendata_DataMuons.root` (real data).