### PR TITLE
Add RNTuple and RNTupleDS LHCB benchmarks

### DIFF
--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -56,7 +56,7 @@ if(rootbench-datafiles)
    if (ROOT_root7_FOUND)
       RB_ADD_GBENCHMARK(RNTupleDSBenchmarks
          RNTupleDSBenchmarks.cxx
-         LIBRARIES Core Hist RIO TreePlayer ROOTDataFrame
+         LIBRARIES Core Hist RIO TreePlayer ROOTNTuple ROOTDataFrame
          DOWNLOAD_DATAFILES B2HHH~none.ntuple
          LABEL short)
    endif()

--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -52,6 +52,14 @@ if(rootbench-datafiles)
            DOWNLOAD_DATAFILES zpeak_data_small.root
            LABEL long)
     endif()
+
+   if (ROOT_root7_FOUND)
+      RB_ADD_GBENCHMARK(RNTupleDSBenchmarks
+         RNTupleDSBenchmarks.cxx
+         LIBRARIES Core Hist RIO TreePlayer ROOTDataFrame
+         DOWNLOAD_DATAFILES B2HHH~none.ntuple
+         LABEL short)
+   endif()
 endif()
 
 add_subdirectory(LoopSUSYFrame)

--- a/root/tree/dataframe/RNTupleDSBenchmarks.cxx
+++ b/root/tree/dataframe/RNTupleDSBenchmarks.cxx
@@ -58,9 +58,7 @@ auto Dataframe(DF &frame)
 
 static void BM_RNTupleDS_LHCB(benchmark::State &state)
 {
-   auto model = ROOT::Experimental::RNTupleModel::Create();
-   auto ntuple =
-      ROOT::Experimental::RNTupleReader::Open(std::move(model), "DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto ntuple = ROOT::Experimental::RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
    const Long64_t nEntries = ntuple->GetNEntries() * (state.range(0) / 100.);
 
    auto df = ROOT::Experimental::MakeNTupleDataFrame("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");

--- a/root/tree/dataframe/RNTupleDSBenchmarks.cxx
+++ b/root/tree/dataframe/RNTupleDSBenchmarks.cxx
@@ -1,0 +1,68 @@
+#include <ROOT/RNTupleDS.hxx>
+#include <ROOT/RDataFrame.hxx>
+
+#include <benchmark/benchmark.h>
+#include <string>
+#include <vector>
+
+#include <rootbench/RBConfig.h>
+
+namespace {
+
+constexpr double kKaonMassMeV = 493.677;
+
+double GetP2(double px, double py, double pz)
+{
+   return px*px + py*py + pz*pz;
+}
+
+double GetKE(double px, double py, double pz)
+{
+   double p2 = GetP2(px, py, pz);
+   return sqrt(p2 + kKaonMassMeV*kKaonMassMeV);
+}
+
+auto Dataframe(ROOT::RDataFrame &frame)
+{
+   auto fn_muon_cut = [](int is_muon) { return !is_muon; };
+   auto fn_k_cut = [](double prob_k) { return prob_k > 0.5; };
+   auto fn_pi_cut = [](double prob_pi) { return prob_pi < 0.5; };
+   auto fn_sum = [](double p1, double p2, double p3) { return p1 + p2 + p3; };
+   auto fn_mass = [](double B_E, double B_P2) { double r = sqrt(B_E*B_E - B_P2); return r; };
+
+   auto df_muon_cut = frame.Filter(fn_muon_cut, {"H1_isMuon"})
+                           .Filter(fn_muon_cut, {"H2_isMuon"})
+                           .Filter(fn_muon_cut, {"H3_isMuon"});
+   auto df_k_cut = df_muon_cut.Filter(fn_k_cut, {"H1_ProbK"})
+                              .Filter(fn_k_cut, {"H2_ProbK"})
+                              .Filter(fn_k_cut, {"H3_ProbK"});
+   auto df_pi_cut = df_k_cut.Filter(fn_pi_cut, {"H1_ProbPi"})
+                            .Filter(fn_pi_cut, {"H2_ProbPi"})
+                            .Filter(fn_pi_cut, {"H3_ProbPi"});
+   auto df_mass = df_pi_cut.Define("B_PX", fn_sum, {"H1_PX", "H2_PX", "H3_PX"})
+                           .Define("B_PY", fn_sum, {"H1_PY", "H2_PY", "H3_PY"})
+                           .Define("B_PZ", fn_sum, {"H1_PZ", "H2_PZ", "H3_PZ"})
+                           .Define("B_P2", GetP2, {"B_PX", "B_PY", "B_PZ"})
+                           .Define("K1_E", GetKE, {"H1_PX", "H1_PY", "H1_PZ"})
+                           .Define("K2_E", GetKE, {"H2_PX", "H2_PY", "H2_PZ"})
+                           .Define("K3_E", GetKE, {"H3_PX", "H3_PY", "H3_PZ"})
+                           .Define("B_E", fn_sum, {"K1_E", "K2_E", "K3_E"})
+                           .Define("B_m", fn_mass, {"B_E", "B_P2"});
+   auto hMass = df_mass.Histo1D<double>({"B_mass", "", 500, 5050, 5500}, "B_m");
+
+   return hMass;
+}
+} // namespace
+
+static void BM_RNTupleDS_LHCB(benchmark::State &state)
+{
+   auto df = ROOT::Experimental::MakeNTupleDataFrame("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto h_ptr = Dataframe(df);
+   for (auto _ : state)
+      *h_ptr;
+   RB::Ensure(int(h_ptr->GetMean()) == 5262);
+   RB::Ensure(int(h_ptr->GetEntries()) == 23895);
+}
+BENCHMARK(BM_RNTupleDS_LHCB)->Unit(benchmark::kMicrosecond)->Iterations(1);
+
+BENCHMARK_MAIN();

--- a/root/tree/tree/CMakeLists.txt
+++ b/root/tree/tree/CMakeLists.txt
@@ -32,4 +32,10 @@ if(ROOT_root7_FOUND AND rootbench-datafiles)
     SETUP "hadd -f404 ${RB_DATASETDIR}/h1dst-lz4.root ${RB_DATASETDIR}/h1dst-lzma.root"
     SETUP "hadd -f506 ${RB_DATASETDIR}/h1dst-zstd.root ${RB_DATASETDIR}/h1dst-lzma.root"
     SETUP "hadd -f0 ${RB_DATASETDIR}/h1dst-none.root ${RB_DATASETDIR}/h1dst-lzma.root")
+
+  RB_ADD_GBENCHMARK(RNTupleLHCBBenchmarks
+   RNTupleLHCBBenchmarks.cxx
+   LABEL short
+   LIBRARIES Core Hist MathCore RIO Tree ROOTNTuple
+   DOWNLOAD_DATAFILES B2HHH~none.ntuple)
 endif()

--- a/root/tree/tree/RNTupleLHCBBenchmarks.cxx
+++ b/root/tree/tree/RNTupleLHCBBenchmarks.cxx
@@ -1,0 +1,94 @@
+#include <ROOT/RNTuple.hxx>
+#include <TH1D.h>
+#include <benchmark/benchmark.h>
+#include <rootbench/RBConfig.h>
+
+namespace {
+constexpr double kKaonMassMeV = 493.677;
+
+double GetP2(double px, double py, double pz)
+{
+   return px * px + py * py + pz * pz;
+}
+
+double GetKE(double px, double py, double pz)
+{
+   double p2 = GetP2(px, py, pz);
+   return sqrt(p2 + kKaonMassMeV * kKaonMassMeV);
+}
+} // namespace
+
+static void BM_RNTuple_LHCB(benchmark::State &state)
+{
+   using RNTupleReader = ROOT::Experimental::RNTupleReader;
+   using RNTupleModel = ROOT::Experimental::RNTupleModel;
+
+   auto model = RNTupleModel::Create();
+   auto ntuple = RNTupleReader::Open(std::move(model), "DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto viewH1IsMuon = ntuple->GetView<int>("H1_isMuon");
+   auto viewH2IsMuon = ntuple->GetView<int>("H2_isMuon");
+   auto viewH3IsMuon = ntuple->GetView<int>("H3_isMuon");
+
+   auto viewH1PX = ntuple->GetView<double>("H1_PX");
+   auto viewH1PY = ntuple->GetView<double>("H1_PY");
+   auto viewH1PZ = ntuple->GetView<double>("H1_PZ");
+   auto viewH1ProbK = ntuple->GetView<double>("H1_ProbK");
+   auto viewH1ProbPi = ntuple->GetView<double>("H1_ProbPi");
+
+   auto viewH2PX = ntuple->GetView<double>("H2_PX");
+   auto viewH2PY = ntuple->GetView<double>("H2_PY");
+   auto viewH2PZ = ntuple->GetView<double>("H2_PZ");
+   auto viewH2ProbK = ntuple->GetView<double>("H2_ProbK");
+   auto viewH2ProbPi = ntuple->GetView<double>("H2_ProbPi");
+
+   auto viewH3PX = ntuple->GetView<double>("H3_PX");
+   auto viewH3PY = ntuple->GetView<double>("H3_PY");
+   auto viewH3PZ = ntuple->GetView<double>("H3_PZ");
+   auto viewH3ProbK = ntuple->GetView<double>("H3_ProbK");
+   auto viewH3ProbPi = ntuple->GetView<double>("H3_ProbPi");
+
+   auto hMass = new TH1D("B_mass", "", 500, 5050, 5500);
+
+   for (auto _ : state) {
+      hMass->Reset();
+      for (auto i : ntuple->GetEntryRange()) {
+         if (viewH1IsMuon(i) || viewH2IsMuon(i) || viewH3IsMuon(i)) {
+            continue;
+         }
+
+         constexpr double prob_k_cut = 0.5;
+         if (viewH1ProbK(i) < prob_k_cut)
+            continue;
+         if (viewH2ProbK(i) < prob_k_cut)
+            continue;
+         if (viewH3ProbK(i) < prob_k_cut)
+            continue;
+
+         constexpr double prob_pi_cut = 0.5;
+         if (viewH1ProbPi(i) > prob_pi_cut)
+            continue;
+         if (viewH2ProbPi(i) > prob_pi_cut)
+            continue;
+         if (viewH3ProbPi(i) > prob_pi_cut)
+            continue;
+
+         double b_px = viewH1PX(i) + viewH2PX(i) + viewH3PX(i);
+         double b_py = viewH1PY(i) + viewH2PY(i) + viewH3PY(i);
+         double b_pz = viewH1PZ(i) + viewH2PZ(i) + viewH3PZ(i);
+         double b_p2 = GetP2(b_px, b_py, b_pz);
+         double k1_E = GetKE(viewH1PX(i), viewH1PY(i), viewH1PZ(i));
+         double k2_E = GetKE(viewH2PX(i), viewH2PY(i), viewH2PZ(i));
+         double k3_E = GetKE(viewH3PX(i), viewH3PY(i), viewH3PZ(i));
+         double b_E = k1_E + k2_E + k3_E;
+         double b_mass = sqrt(b_E * b_E - b_p2);
+         hMass->Fill(b_mass);
+      }
+   }
+   RB::Ensure(int(hMass->GetMean()) == 5262);
+   RB::Ensure(int(hMass->GetEntries()) == 23895);
+   delete hMass;
+}
+BENCHMARK(BM_RNTuple_LHCB)->Unit(benchmark::kMicrosecond)->Iterations(3);
+
+BENCHMARK_MAIN();
+

--- a/root/tree/tree/RNTupleLHCBBenchmarks.cxx
+++ b/root/tree/tree/RNTupleLHCBBenchmarks.cxx
@@ -23,8 +23,7 @@ static void BM_RNTuple_LHCB(benchmark::State &state)
    using RNTupleReader = ROOT::Experimental::RNTupleReader;
    using RNTupleModel = ROOT::Experimental::RNTupleModel;
 
-   auto model = RNTupleModel::Create();
-   auto ntuple = RNTupleReader::Open(std::move(model), "DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto ntuple = RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
    auto viewH1IsMuon = ntuple->GetView<int>("H1_isMuon");
    auto viewH2IsMuon = ntuple->GetView<int>("H2_isMuon");
    auto viewH3IsMuon = ntuple->GetView<int>("H3_isMuon");
@@ -54,8 +53,6 @@ static void BM_RNTuple_LHCB(benchmark::State &state)
    for (auto _ : state) {
       hMass->Reset();
       for (auto i = 0ll; i < nEntries; ++i) {
-         ntuple->LoadEntry(i);
-
          if (viewH1IsMuon(i) || viewH2IsMuon(i) || viewH3IsMuon(i)) {
             continue;
          }

--- a/root/tree/tree/RNTupleLHCBBenchmarks.cxx
+++ b/root/tree/tree/RNTupleLHCBBenchmarks.cxx
@@ -49,9 +49,13 @@ static void BM_RNTuple_LHCB(benchmark::State &state)
 
    auto hMass = new TH1D("B_mass", "", 500, 5050, 5500);
 
+   const Long64_t nEntries = ntuple->GetNEntries() * (state.range(0) / 100.);
+
    for (auto _ : state) {
       hMass->Reset();
-      for (auto i : ntuple->GetEntryRange()) {
+      for (auto i = 0ll; i < nEntries; ++i) {
+         ntuple->LoadEntry(i);
+
          if (viewH1IsMuon(i) || viewH2IsMuon(i) || viewH3IsMuon(i)) {
             continue;
          }
@@ -84,11 +88,15 @@ static void BM_RNTuple_LHCB(benchmark::State &state)
          hMass->Fill(b_mass);
       }
    }
-   RB::Ensure(int(hMass->GetMean()) == 5262);
-   RB::Ensure(int(hMass->GetEntries()) == 23895);
+   if (state.range(0) == 100) {
+      // sanity checks
+      RB::Ensure(int(hMass->GetMean()) == 5262);
+      RB::Ensure(int(hMass->GetEntries()) == 23895);
+   }
    delete hMass;
 }
-BENCHMARK(BM_RNTuple_LHCB)->Unit(benchmark::kMicrosecond)->Iterations(3);
+// Arg is the % of events to be processed
+BENCHMARK(BM_RNTuple_LHCB)->Unit(benchmark::kMicrosecond)->Iterations(5)->Arg(100)->Arg(50)->Arg(25);
 
 BENCHMARK_MAIN();
 


### PR DESCRIPTION
Currently only running on uncompressed rntuple data, to accentuate the overhead of RNTupleDS.