### PR TITLE
Fix stopwatch in RNTuple benchmarks

### DIFF
--- a/root/tree/tree/RNTupleH1Benchmarks.cxx
+++ b/root/tree/tree/RNTupleH1Benchmarks.cxx
@@ -58,9 +58,10 @@ static void BM_RNTuple_H1(benchmark::State &state, const std::string &comprAlgor
       for (auto i : ntuple->GetEntryRange()) {
          if (i == 0) {
             state.PauseTiming();
-         } else {
+         } else if (i == 1) {
             state.ResumeTiming();
          }
+
          auto ik = ikView(i) - 1;
          auto ipi = ipiView(i) - 1;
          auto ipis = ipisView(i) - 1;
@@ -165,9 +166,9 @@ static void BM_TTree_H1(benchmark::State &state, const std::string &comprAlgorit
       auto hdmd = new TH1D("hdmd", "dm_d", 40, 0.13, 0.17);
       auto h2 = new TH2D("h2", "ptD0 vs dm_d", 30, 0.135, 0.165, 30, -3, 6);
       for (decltype(nEntries) entryId = 0; entryId < nEntries; ++entryId) {
-         if (entryId == 1) {
+         if (entryId == 0) {
             state.PauseTiming();
-         } else if (entryId == 2) {
+         } else if (entryId == 1) {
             state.ResumeTiming();
          }
 


### PR DESCRIPTION
Fix running time measurement such that both TTree and RNTuple benchmarks count as of the second event. Fixes #184 

Results should look more like this now

```
35: ---------------------------------------------------------------------------------------
35: Benchmark                                             Time             CPU   Iterations
35: ---------------------------------------------------------------------------------------
35: BM_RNTuple_H1/BM_RNTuple_H1LZ4/iterations:5       14605 us        14340 us            5
35: BM_RNTuple_H1/BM_RNTuple_H1ZLIB/iterations:5     108539 us       108198 us            5
35: BM_RNTuple_H1/BM_RNTuple_H1LZMA/iterations:5     812103 us       810074 us            5
35: BM_RNTuple_H1/BM_RNTuple_H1ZSTD/iterations:5      40349 us        40307 us            5
35: BM_RNTuple_H1/BM_RNTuple_H1None/iterations:5       6715 us         6200 us            5
35: BM_TTree_H1/BM_TTree_H1LZ4/iterations:5           24996 us        24964 us            5
35: BM_TTree_H1/BM_TTree_H1ZLIB/iterations:5         129451 us       129316 us            5
35: BM_TTree_H1/BM_TTree_H1LZMA/iterations:5         844737 us       843945 us            5
35: BM_TTree_H1/BM_TTree_H1ZSTD/iterations:5          48668 us        48614 us            5
35: BM_TTree_H1/BM_TTree_H1None/iterations:5          16256 us        16232 us            5
11/11 Test #35: rootbench-RNTupleAnalysisBenchmarks ....................   Passed   10.66 sec
```