### PR TITLE
[DF][PyROOT] Add AsNumpy benchmarks

### DIFF
--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -4,8 +4,11 @@ RB_ADD_GBENCHMARK(RDFBenchmarks
     LABEL short
     LIBRARIES Core Hist Imt RIO Tree TreePlayer ROOTDataFrame ROOTVecOps)
 
-if(NUMPY_FOUND)
-    RB_ADD_PYTESTBENCHMARK(pytest-rdataframe-asnumpy rdataframe_asnumpy.py LABEL short)
+if(NUMPY_FOUND AND rootbench-datafiles)
+    RB_ADD_PYTESTBENCHMARK(pytest-rdataframe-asnumpy
+        rdataframe_asnumpy.py
+        DOWNLOAD_DATAFILES Run2012BC_DoubleMuParked_Muons.root data_A.GamGam.100k.root
+        LABEL long)
 endif()
 
 if(rootbench-datafiles)

--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -7,7 +7,7 @@ RB_ADD_GBENCHMARK(RDFBenchmarks
 if(NUMPY_FOUND AND rootbench-datafiles)
     RB_ADD_PYTESTBENCHMARK(pytest-rdataframe-asnumpy
         rdataframe_asnumpy.py
-        DOWNLOAD_DATAFILES Run2012BC_DoubleMuParked_Muons.root data_A.GamGam.100k.root
+        DOWNLOAD_DATAFILES Run2012BC_DoubleMuParked_Muons.root data_A.GamGam.root
         LABEL long)
 endif()
 

--- a/root/tree/dataframe/rdataframe_asnumpy.py
+++ b/root/tree/dataframe/rdataframe_asnumpy.py
@@ -99,6 +99,8 @@ def test_rdataframe_asnumpy_manybranches_scalars_imt(benchmark):
     columns = get_column_names(scalars=True)
     benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)
 
+# NOTE: These benchmarks are disabled due to time constraints
+'''
 def test_rdataframe_asnumpy_manybranches_vectors_noimit(benchmark):
     ROOT.DisableImplicitMT()
     columns = get_column_names(vectors=True)
@@ -118,3 +120,4 @@ def test_rdataframe_asnumpy_manybranches_all_imt(benchmark):
     ROOT.DisableImplicitMT()
     columns = get_column_names(vectors=True, scalars=True, booleans=True)
     benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)
+'''

--- a/root/tree/dataframe/rdataframe_asnumpy.py
+++ b/root/tree/dataframe/rdataframe_asnumpy.py
@@ -5,7 +5,7 @@ import os
 import ROOT
 
 nanoaod_file = os.path.join(os.environ["RB_DATASETDIR"], "Run2012BC_DoubleMuParked_Muons.root")
-ntuple_file = os.path.join(os.environ["RB_DATASETDIR"], "data_A.GamGam.100k.root")
+ntuple_file = os.path.join(os.environ["RB_DATASETDIR"], "data_A.GamGam.root")
 
 # Simple AsNumpy benchmark processing a minimal amount of data from memory
 

--- a/root/tree/dataframe/rdataframe_asnumpy.py
+++ b/root/tree/dataframe/rdataframe_asnumpy.py
@@ -1,8 +1,13 @@
 import numpy as np
 import pytest
+import os
 
 import ROOT
 
+nanoaod_file = os.path.join(os.environ["RB_DATASETDIR"], "Run2012BC_DoubleMuParked_Muons.root")
+ntuple_file = os.path.join(os.environ["RB_DATASETDIR"], "data_A.GamGam.100k.root")
+
+# Simple AsNumpy benchmark processing a minimal amount of data from memory
 
 def payload_asnumpy_simple():
     df = ROOT.RDataFrame(10)
@@ -10,5 +15,106 @@ def payload_asnumpy_simple():
     return np.sum(x['x'])
 
 def test_rdataframe_asnumpy_simple(benchmark):
+    ROOT.DisableImplicitMT()
     r = benchmark(payload_asnumpy_simple)
     assert(r == 45)
+
+# Read from a NanoAOD file a scalar type branch with millions of events
+
+def payload_asnumpy_nanoaod_scalar(nthreads):
+    if nthreads > 1: ROOT.EnableImplicitMT(nthreads)
+    df = ROOT.RDataFrame('Events', nanoaod_file)
+    df.AsNumpy(['nMuon'])
+
+def test_rdataframe_asnumpy_nanoaod_scalar_noimt(benchmark):
+    ROOT.DisableImplicitMT()
+    benchmark.pedantic(payload_asnumpy_nanoaod_scalar, kwargs={'nthreads': 1}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_nanoaod_scalar_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    benchmark.pedantic(payload_asnumpy_nanoaod_scalar, kwargs={'nthreads': 8}, iterations=1, rounds=1)
+
+# Read from a NanoAOD file a vector type branch with millions of events
+
+def payload_asnumpy_nanoaod_vector(nthreads):
+    if nthreads > 1: ROOT.EnableImplicitMT(nthreads)
+    df = ROOT.RDataFrame('Events', nanoaod_file)
+    df.AsNumpy(['Muon_pt'])
+
+def test_rdataframe_asnumpy_nanoaod_vector_noimt(benchmark):
+    ROOT.DisableImplicitMT()
+    benchmark.pedantic(payload_asnumpy_nanoaod_vector, kwargs={'nthreads': 1}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_nanoaod_vector_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    benchmark.pedantic(payload_asnumpy_nanoaod_vector, kwargs={'nthreads': 8}, iterations=1, rounds=1)
+
+# Read from a flat ntuple file of a small size branches in various configurations
+
+def payload_asnumpy_manybranches(nthreads, columns):
+    if nthreads > 1: ROOT.EnableImplicitMT(nthreads)
+    df = ROOT.RDataFrame('mini', ntuple_file)
+    df.AsNumpy(columns)
+
+def get_column_names(vectors=False, booleans=False, scalars=False):
+    '''
+    Get column names for the "manybranches" benchmarks
+
+    Arguments:
+        vectors: boolean, take columns with vectors (containing rvec in the typename)
+        booleans: boolean, take columns with booleans
+        scalars: boolean, take columns with other scalar types (containing int and float in the typename)
+
+    Returns:
+        vector<string> of column names
+    '''
+    df = ROOT.RDataFrame('mini', ntuple_file)
+    columns = ROOT.std.vector('string')()
+    for col in df.GetColumnNames():
+        typename = str(df.GetColumnType(col)).lower()
+        is_boolean = True if 'bool' in typename else False
+        is_vector = True if 'rvec' in typename else False
+        is_scalar = True if 'int' in typename or 'float' in typename else False
+        if (vectors and is_vector) or (booleans and is_boolean) or (scalars and is_scalar):
+            columns.push_back(col)
+    return columns
+
+def test_rdataframe_asnumpy_manybranches_booleans_noimit(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(booleans=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 1, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_booleans_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(booleans=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_scalars_noimit(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(scalars=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 1, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_scalars_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(scalars=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_vectors_noimit(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(vectors=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 1, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_vectors_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(vectors=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_all_noimit(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(vectors=True, scalars=True, booleans=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 1, 'columns': columns}, iterations=1, rounds=1)
+
+def test_rdataframe_asnumpy_manybranches_all_imt(benchmark):
+    ROOT.DisableImplicitMT()
+    columns = get_column_names(vectors=True, scalars=True, booleans=True)
+    benchmark.pedantic(payload_asnumpy_manybranches, kwargs={'nthreads': 8, 'columns': columns}, iterations=1, rounds=1)


### PR DESCRIPTION
There's now a comprehensive benchmark suite regarding `RDataFrame.AsNumpy`. There are two benchmark running almost a minute, however, I would love to see huge amounts of data read into memory. That's what we have to optimize for ML applications and friends. Here the runtimes:

```
--------------------------------------------------------------------------------------------------------- benchmark: 13 tests ----------------------------------------------------------------------------------------------------------
12: Name (time in ms)                                                Min                    Max                   Mean            StdDev                 Median               IQR            Outliers      OPS            Rounds  Iterations
12: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
12: test_rdataframe_asnumpy_simple                               21.6676 (1.0)          23.1801 (1.0)          22.1736 (1.0)      0.6036 (inf)          21.8962 (1.0)      0.6904 (inf)           1;0  45.0987 (1.0)           5           1
12: test_rdataframe_asnumpy_manybranches_booleans_imt         2,698.8600 (124.56)    2,698.8600 (116.43)    2,698.8600 (121.72)   0.0000 (1.0)       2,698.8600 (123.26)   0.0000 (1.0)           0;0   0.3705 (0.01)          1           1
12: test_rdataframe_asnumpy_manybranches_booleans_noimit      3,404.0005 (157.10)    3,404.0005 (146.85)    3,404.0005 (153.52)   0.0000 (1.0)       3,404.0005 (155.46)   0.0000 (1.0)           0;0   0.2938 (0.01)          1           1
12: test_rdataframe_asnumpy_nanoaod_scalar_imt                3,576.4014 (165.06)    3,576.4014 (154.29)    3,576.4014 (161.29)   0.0000 (1.0)       3,576.4014 (163.33)   0.0000 (1.0)           0;0   0.2796 (0.01)          1           1
12: test_rdataframe_asnumpy_nanoaod_scalar_noimt              7,675.9396 (354.26)    7,675.9396 (331.14)    7,675.9396 (346.17)   0.0000 (1.0)       7,675.9396 (350.56)   0.0000 (1.0)           0;0   0.1303 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_scalars_imt          9,195.2222 (424.38)    9,195.2222 (396.69)    9,195.2222 (414.69)   0.0000 (1.0)       9,195.2222 (419.95)   0.0000 (1.0)           0;0   0.1088 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_vectors_noimit       9,340.0237 (431.06)    9,340.0237 (402.93)    9,340.0237 (421.22)   0.0000 (1.0)       9,340.0237 (426.56)   0.0000 (1.0)           0;0   0.1071 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_scalars_noimit       9,744.4360 (449.72)    9,744.4360 (420.38)    9,744.4360 (439.46)   0.0000 (1.0)       9,744.4360 (445.03)   0.0000 (1.0)           0;0   0.1026 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_vectors_imt          9,786.9802 (451.69)    9,786.9802 (422.22)    9,786.9802 (441.38)   0.0000 (1.0)       9,786.9802 (446.97)   0.0000 (1.0)           0;0   0.1022 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_all_noimit          12,603.9666 (581.70)   12,603.9666 (543.74)   12,603.9666 (568.42)   0.0000 (1.0)      12,603.9666 (575.62)   0.0000 (1.0)           0;0   0.0793 (0.00)          1           1
12: test_rdataframe_asnumpy_manybranches_all_imt             13,550.1253 (625.36)   13,550.1253 (584.56)   13,550.1253 (611.09)   0.0000 (1.0)      13,550.1253 (618.83)   0.0000 (1.0)           0;0   0.0738 (0.00)          1           1
12: test_rdataframe_asnumpy_nanoaod_vector_imt               49,896.4716 (>1000.0)  49,896.4716 (>1000.0)  49,896.4716 (>1000.0)  0.0000 (1.0)      49,896.4716 (>1000.0)  0.0000 (1.0)           0;0   0.0200 (0.00)          1           1
12: test_rdataframe_asnumpy_nanoaod_vector_noimt             67,270.0734 (>1000.0)  67,270.0734 (>1000.0)  67,270.0734 (>1000.0)  0.0000 (1.0)      67,270.0734 (>1000.0)  0.0000 (1.0)           0;0   0.0149 (0.00)          1           1
12: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```