### PR TITLE
[DF] Flush global cache of code-to-jit at benchmark end

### DIFF
--- a/root/tree/dataframe/RDataFrameBenchmarks.cxx
+++ b/root/tree/dataframe/RDataFrameBenchmarks.cxx
@@ -45,6 +45,9 @@ static void BM_RDataFrame_DefineJitted(benchmark::State &state)
 {
    for (auto _ : state)
       RDataFrame(0).Define("d", "0");
+
+   // trigger actual jitting and clean cache of code to be jitted
+   RDataFrame(0).Count().GetValue();
 }
 BENCHMARK(BM_RDataFrame_DefineJitted)->Unit(benchmark::kMicrosecond);
 
@@ -64,6 +67,9 @@ static void BM_RDataFrame_FilterJitted(benchmark::State &state)
 {
    for (auto _ : state)
       RDataFrame(0).Filter("true");
+
+   // trigger actual jitting and clean cache of code to be jitted
+   RDataFrame(0).Count().GetValue();
 }
 BENCHMARK(BM_RDataFrame_FilterJitted)->Unit(benchmark::kMicrosecond);
 


### PR DESCRIPTION
Otherwise we end up accumulating a crazy amount of code to be jitted
that changes the runtime of the first subsequent event loop.

Unfortunately we cannot simply drop the code to be jitted because
it also needs to perform certain clean-up operations, see
https://sft.its.cern.ch/jira/browse/ROOT-10724.