### PR TITLE
The rt library does not exist on osx.

### DIFF
--- a/cmake/modules/AddRootBench.cmake
+++ b/cmake/modules/AddRootBench.cmake
@@ -43,7 +43,10 @@ function(RB_ADD_GBENCHMARK benchmark)
   # FIXME: For better coherence we could restrict the libraries the test suite could link
   # against. For example, tests in Core should link only against libCore. This could be tricky
   # to implement because some ROOT components create more than one library.
-  target_link_libraries(${benchmark} ${ARG_LIBRARIES} gbenchmark RBSupport rt)
+  target_link_libraries(${benchmark} PUBLIC ${ARG_LIBRARIES} gbenchmark RBSupport)
+  if (NOT APPLE)
+    target_link_libraries(${benchmark} PUBLIC rt)
+  endif()
   #ROOT_PATH_TO_STRING(mangled_name ${benchmark} PATH_SEPARATOR_REPLACEMENT "-")
   #ROOT_ADD_TEST(gbench${mangled_name}
   #  COMMAND ${benchmark}


### PR DESCRIPTION
Fixes root-project/rootbench#208