### PR TITLE
Call RooAddPdf::fixNormalizationCoefficient to avoid warning messages.

### DIFF
--- a/root/roofit/vectorisedPDFs/benchAddPdf.cxx
+++ b/root/roofit/vectorisedPDFs/benchAddPdf.cxx
@@ -79,6 +79,8 @@ static void benchAddPdfGaussExp(benchmark::State& state) {
 
   RooRealVar fractionGaus("fractionGaus", "Fraction of Gauss component", 0.5, 0., 1.);
   RooAddPdf pdf("SumGausPois", "Sum of Gaus and Poisson", RooArgSet(gauss, ex), fractionGaus);
+  // to avoid a warning when computing the   unnormalized RooAddPdf values
+  pdf.fixCoefNormalization(x);
 
   auto data = pdf.generate(RooArgSet(x), nEvents);
 

--- a/root/roofit/vectorisedPDFs/benchJohnson.cxx
+++ b/root/roofit/vectorisedPDFs/benchJohnson.cxx
@@ -76,6 +76,8 @@ static void benchJohnsonPlusExp(benchmark::State& state) {
 
   RooRealVar a("a", "a", 0.5, 0., 1.);
   RooAddPdf sum("sum", "Johnson+exp", johnson, exp, a);
+  // to avoid a warning when computing the unnormalized RooAddPdf values
+  sum.fixCoefNormalization(mass);
 
 
   RooAbsPdf& pdf = sum;


### PR DESCRIPTION
One needs to fix the normalisation of the RooAddPdf to avoid having tons of warning when evaluating the un-normalized RooAddPdf in the benchmark tests. 