### PR TITLE
[DF] Add benchmark for jitting large DF graphs

### DIFF
--- a/root/tree/dataframe/RDataFrameBenchmarks.cxx
+++ b/root/tree/dataframe/RDataFrameBenchmarks.cxx
@@ -183,4 +183,22 @@ static void BM_RDataFrame_FillHistoRangeDeductionMT(benchmark::State &state)
 BENCHMARK(BM_RDataFrame_FillHistoRangeDeductionMT)->Unit(benchmark::kMicrosecond)->Arg(100)->Arg(100000)->Iterations(100);
 #endif // R__USE_IMT
 
+static void BM_RDataFrame_JitLargeGraphs(benchmark::State &state)
+{
+   for (auto _ : state) {
+    ROOT::RDataFrame root(1);
+    std::vector<ROOT::RDF::RResultPtr<double>> dfs;
+    const auto n = state.range(0);
+    for (auto i = 0u; i < n; i++) {
+        const auto column = "x" + std::to_string(i);
+        auto define = root.Define(column, "42.f");
+        auto filter = define.Filter(column + " > 0.f");
+        auto sum = filter.Sum(column);
+        dfs.emplace_back(sum);
+    }
+    dfs[n - 1].GetValue();
+   }
+}
+BENCHMARK(BM_RDataFrame_JitLargeGraphs)->Unit(benchmark::kMicrosecond)->Arg(100)->Arg(1000)->Arg(10000);
+
 BENCHMARK_MAIN();

--- a/root/tree/dataframe/RDataFrameBenchmarks.cxx
+++ b/root/tree/dataframe/RDataFrameBenchmarks.cxx
@@ -183,6 +183,9 @@ static void BM_RDataFrame_FillHistoRangeDeductionMT(benchmark::State &state)
 BENCHMARK(BM_RDataFrame_FillHistoRangeDeductionMT)->Unit(benchmark::kMicrosecond)->Arg(100)->Arg(100000)->Iterations(100);
 #endif // R__USE_IMT
 
+// The graph here has a large breadth but small depth, which results in a large jitting time
+// but a very short runtime of the actual event loop. Therefore this benchmark is almost
+// exclusively measuring the jitting time.
 static void BM_RDataFrame_JitLargeGraphs(benchmark::State &state)
 {
    for (auto _ : state) {


### PR DESCRIPTION
Here are the results I got by running it locally. master vs https://github.com/root-project/root/pull/7651:

```
# master
10: BM_RDataFrame_JitLargeGraphs/100                                  839628 us       832963 us            1
10: BM_RDataFrame_JitLargeGraphs/1000                                3170937 us      3165917 us            1
10: BM_RDataFrame_JitLargeGraphs/10000                              38968494 us     38905225 us            1

# optimized
10: BM_RDataFrame_JitLargeGraphs/100                                  683157 us       677816 us            1
10: BM_RDataFrame_JitLargeGraphs/1000                                1284963 us      1282854 us            1
10: BM_RDataFrame_JitLargeGraphs/10000                              11771816 us     11750960 us            1
```