### PR TITLE
Improved benchmarking of compression algorithms

### DIFF
--- a/cmake/modules/RootBenchOptions.cmake
+++ b/cmake/modules/RootBenchOptions.cmake
@@ -4,4 +4,11 @@
 # # TBD: to introduce special function for options (similar to root.git)
 #----------------------------------------------------------------------------
 option(coverage OFF)
-option(rootbench-datafiles OFF)
+
+option(rootbench-datafiles OFF "Download files from root.cern.ch")
+
+option(experiment-datafiles OFF "Use for benchmarking CMS and ATLAS files (> 1.5 GB)")
+if(experiment-datafiles)
+    # We need to enable download of datafiles from oot.cern.ch
+    set(rootbench-datafiles ON CACHE BOOL "Download files from root.cern.ch" FORCE)
+endif()

--- a/root/io/io/CMakeLists.txt
+++ b/root/io/io/CMakeLists.txt
@@ -7,10 +7,11 @@ if(ROOT_root7_FOUND) # using ROOT_root7_FOUND as a proxy for "c++ standard >= 14
   RB_ADD_GBENCHMARK(TFile_RDFSnapshot
     TFile_RDFSnapshot.cxx
     LABEL short
-  LIBRARIES Core RIO ROOTDataFrame Tree TreePlayer MathCore)
+    LIBRARIES Core RIO ROOTDataFrame Tree TreePlayer MathCore)
 endif()
 
-if(rootbench-datafiles)
+if(rootbench-datafiles AND experiment-datafiles)
+
   # FIXME:Compression tests needs to have libEvent.so which is a part of ROOT build
   # Preloading doesn't help...
   #if(TARGET Event)
@@ -21,22 +22,21 @@ if(rootbench-datafiles)
   #    DOWNLOAD_DATAFILES Event0-sample.root)
   #endif()
 
-  # FIXME: too long benchmarks, needs to be optimised
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_LHCb
-  #  TFile_LHCb_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_LHCb
+    TFile_LHCb_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO Tree
+    DOWNLOAD_DATAFILES lhcb_B2ppKK2011_md_noPIDstrip.root)
 
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_NanoAOD
-  #  TFile_NanoAOD_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_NanoAOD
+    TFile_NanoAOD_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO Tree
+    DOWNLOAD_DATAFILES Run2012B_DoubleMuParked.root NanoAOD_DoubleMuon_CMS2011OpenData.root)
 
-  #RB_ADD_GBENCHMARK(CompressionBenchmarks_ATLAS
-  #  TFile_ATLAS_Benchmarks.cxx
-  #  LABEL short
-  #  LIBRARIES Core RIO
-  #  DOWNLOAD_DATAFILES gg_data-zstd.root)
+  RB_ADD_GBENCHMARK(CompressionBenchmarks_ATLAS
+    TFile_ATLAS_Benchmarks.cxx
+    LABEL short
+    LIBRARIES Core RIO Tree
+    DOWNLOAD_DATAFILES gg_data-zstd.root)
 endif()

--- a/root/io/io/TFile_ATLAS_Benchmarks.cxx
+++ b/root/io/io/TFile_ATLAS_Benchmarks.cxx
@@ -1,10 +1,12 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TStopwatch.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
 
 #include <map>
+#include <iostream>
 
 static std::string GetAlgoName(int algo) {
     std::map<int, std::string> algoName = {
@@ -21,47 +23,57 @@ static std::string GetAlgoName(int algo) {
 }
 
 static void BM_ATLAS_Compress(benchmark::State &state, int algo) {
-    TFile *oldfile = new TFile((RB::GetDataDir() + "/gg_data-zstd.root").c_str());
-    TTree *oldtree = (TTree*)oldfile->Get("mini");
-
+    std::string path = RB::GetDataDir() + "/gg_data-zstd.root";
+    auto oldfile = TFile::Open(path.c_str());
+    auto oldtree = oldfile->Get<TTree>("mini");
+    TStopwatch timer;
+    const auto nevents = oldtree->GetEntries();
     int comp_level = state.range(0);
     std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
 
     for (auto _ : state) {
         state.PauseTiming();
-
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree = oldtree->CloneTree();
+        auto newfile = new TFile(filename.c_str(), "recreate");
         newfile->SetCompressionAlgorithm(algo);
         newfile->SetCompressionLevel(comp_level);
+        auto newtree = oldtree->CloneTree();
 
         state.ResumeTiming();
+        timer.Start();
         newfile->Write();
+        timer.Stop();
         state.PauseTiming();
 
-        state.counters["comp_size"] = newfile->GetBytesWritten();
+        state.counters["comp_size"] = newfile->GetSize();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        state.counters["mb_rts"] = newfile->GetSize()/rtime;
+        state.counters["mb_cts"] = newfile->GetSize()/ctime;
         newfile->Close();
-
         state.ResumeTiming();
     }
 }
 
 static void BM_ATLAS_Decompress(benchmark::State &state, int algo) {
     int comp_level = state.range(0);
-
+    int nb;
+    TStopwatch timer;
     std::string filename = "level_" + std::to_string(comp_level) + "_atlas_" + GetAlgoName(algo) + ".root";
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
-        TTree *tree = (TTree*)hfile->Get("mini");
-
-        Int_t nevent = (Int_t)tree->GetEntries();
-
-        Int_t nb = 0;
+        timer.Start();
+        TFile f(filename.c_str());
+        auto tree = static_cast<TTree *>(f.Get("mini"));
+        const auto nevents = tree->GetEntries();
         Int_t ev;
-
-        for (ev = 0; ev < nevent; ev++) {
+        for (ev = 0; ev < nevents; ++ev) {
             nb += tree->GetEntry(ev);
         }
+        timer.Stop();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        state.counters["mb_rts"] = f.GetSize()/rtime;
+        state.counters["mb_cts"] = f.GetSize()/ctime;
+        f.Close();
     }
 }
 
@@ -91,39 +103,38 @@ static void BM_ATLAS_Decompress_ZSTD(benchmark::State &state) {
     BM_ATLAS_Decompress(state, 5);
 }
 
-
 BENCHMARK(BM_ATLAS_Compress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Compress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Compress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Compress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 
 BENCHMARK(BM_ATLAS_Decompress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Decompress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Decompress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_ATLAS_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 
 BENCHMARK_MAIN(); 

--- a/root/io/io/TFile_CompressionBenchmarks_MainEvent.cxx
+++ b/root/io/io/TFile_CompressionBenchmarks_MainEvent.cxx
@@ -102,8 +102,6 @@ static void BM_MainEvent_Decompress_ZSTD(benchmark::State &state) {
    BM_MainEvent_Decompress(state, 5);
 }
 
-
-
 BENCHMARK(BM_MainEvent_Compress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
 ->Unit(benchmark::kMillisecond)->Iterations(5);
@@ -136,6 +134,7 @@ BENCHMARK(BM_MainEvent_Decompress_LZ4)
 BENCHMARK(BM_MainEvent_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
 ->Unit(benchmark::kMillisecond)->Iterations(5);
+
 
 
 BENCHMARK_MAIN();

--- a/root/io/io/TFile_LHCb_Benchmarks.cxx
+++ b/root/io/io/TFile_LHCb_Benchmarks.cxx
@@ -1,5 +1,6 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TStopwatch.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
@@ -21,6 +22,7 @@ static std::string GetAlgoName(int algo) {
 }
 
 static void BM_LHCb_Compress(benchmark::State &state, int algo) {
+    TStopwatch timer;
     TFile *oldfile = new TFile((RB::GetDataDir() + "/lhcb_B2ppKK2011_md_noPIDstrip.root").c_str());
     TTree *oldtree1 = (TTree*)oldfile->Get("TupleB2ppKK/DecayTree");
     TTree *oldtree2 = (TTree*)oldfile->Get("TupleB2ppKPi/DecayTree");
@@ -31,19 +33,24 @@ static void BM_LHCb_Compress(benchmark::State &state, int algo) {
 
     for (auto _ : state) {
         state.PauseTiming();
-
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree1 = oldtree1->CloneTree();
-        TTree *newtree2 = oldtree2->CloneTree();
-        TTree *newtree3 = oldtree3->CloneTree();
+        auto newfile = new TFile(filename.c_str(), "recreate");
         newfile->SetCompressionAlgorithm(algo);
         newfile->SetCompressionLevel(comp_level);
+        auto newtree1 = oldtree1->CloneTree();
+        auto newtree2 = oldtree2->CloneTree();
+        auto newtree3 = oldtree3->CloneTree();
 
         state.ResumeTiming();
+        timer.Start();
         newfile->Write();
+        timer.Stop();
         state.PauseTiming();
 
-        state.counters["comp_size"] = newfile->GetBytesWritten();
+        state.counters["comp_size"] = newfile->GetSize();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        state.counters["mb_rts"] = newfile->GetSize()/rtime;
+        state.counters["mb_cts"] = newfile->GetSize()/ctime;
         newfile->Close();
 
         state.ResumeTiming();
@@ -52,32 +59,35 @@ static void BM_LHCb_Compress(benchmark::State &state, int algo) {
 
 static void BM_LHCb_Decompress(benchmark::State &state, int algo) {
     int comp_level = state.range(0);
-
+    TStopwatch timer;
     std::string filename = "level_" + std::to_string(comp_level) + "_lhcb_" + GetAlgoName(algo) + ".root";
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
-        TTree *tree1 = (TTree*)hfile->Get("TupleB2ppKK/DecayTree");
-        TTree *tree2 = (TTree*)hfile->Get("TupleB2ppKPi/DecayTree");
-        TTree *tree3 = (TTree*)hfile->Get("TupleB2ppPiPi/DecayTree");
-
-        Int_t nevent1 = (Int_t)tree1->GetEntries();
-        Int_t nevent2 = (Int_t)tree2->GetEntries();
-        Int_t nevent3 = (Int_t)tree3->GetEntries();
+        timer.Start();
+        TFile f(filename.c_str());
+        auto tree1 = static_cast<TTree *>(f.Get("TupleB2ppKK/DecayTree"));
+        auto tree2 = static_cast<TTree *>(f.Get("TupleB2ppKPi/DecayTree"));
+        auto tree3 = static_cast<TTree *>(f.Get("TupleB2ppPiPi/DecayTree"));
+        const auto nevent1 = tree1->GetEntries();
+        const auto nevent2 = tree2->GetEntries();
+        const auto nevent3 = tree3->GetEntries();
 
         Int_t nb = 0;
         Int_t ev;
-
-        for (ev = 0; ev < nevent1; ev++) {
+        for (ev = 0; ev < nevent1; ++ev) {
             nb += tree1->GetEntry(ev);
         }
-
-        for (ev = 0; ev < nevent2; ev++) {
+        for (ev = 0; ev < nevent2; ++ev) {
             nb += tree2->GetEntry(ev);
         }
-
-        for (ev = 0; ev < nevent3; ev++) {
+        for (ev = 0; ev < nevent3; ++ev) {
             nb += tree3->GetEntry(ev);
         }
+        timer.Stop();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        state.counters["mb_rts"] = f.GetSize()/rtime;
+        state.counters["mb_cts"] = f.GetSize()/ctime;
+        f.Close();
     }
 }
 
@@ -110,36 +120,35 @@ static void BM_LHCb_Decompress_ZSTD(benchmark::State &state) {
 
 BENCHMARK(BM_LHCb_Compress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Compress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Compress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Compress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
-
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Decompress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Decompress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Decompress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_LHCb_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 
 BENCHMARK_MAIN(); 

--- a/root/io/io/TFile_NanoAOD_Benchmarks.cxx
+++ b/root/io/io/TFile_NanoAOD_Benchmarks.cxx
@@ -1,5 +1,6 @@
 #include "TFile.h"
 #include "TTree.h"
+#include "TStopwatch.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
@@ -21,47 +22,67 @@ static std::string GetAlgoName(int algo) {
 }
 
 static void BM_NanoAOD_Compress(benchmark::State &state, int algo) {
-    TFile *oldfile = new TFile((RB::GetDataDir() + "/Run2012B_DoubleMuParked.root").c_str());
-    TTree *oldtree = (TTree*)oldfile->Get("Events");
-
+    std::string path = RB::GetDataDir() + "/Run2012B_DoubleMuParked.root";
+    //std::string path = RB::GetDataDir() + "/NanoAOD_DoubleMuon_CMS2011OpenData.root";
+    auto oldfile = TFile::Open(path.c_str());
+    auto oldtree = oldfile->Get<TTree>("Events");
+    TStopwatch timer;
+    const auto nevents = oldtree->GetEntries();
     int comp_level = state.range(0);
     std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
 
     for (auto _ : state) {
         state.PauseTiming();
 
-        TFile *newfile = new TFile(filename.c_str(), "recreate");
-        TTree *newtree = oldtree->CloneTree();
+        auto newfile = new TFile(filename.c_str(), "recreate");
         newfile->SetCompressionAlgorithm(algo);
         newfile->SetCompressionLevel(comp_level);
+        auto newtree = oldtree->CloneTree();
 
         state.ResumeTiming();
+        timer.Start();
         newfile->Write();
+        timer.Stop();
         state.PauseTiming();
 
-        state.counters["comp_size"] = newfile->GetBytesWritten();
+        state.counters["comp_size"] = newfile->GetSize();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        // For Run2012B_DoubleMuParked.root:
+        float size_mb = 774.619423;
+        // For NanoAOD_DoubleMuon_CMS2011OpenData.root:
+        //float size_mb = 774.619423;
+        state.counters["mb_rts"] = size_mb/rtime;
+        state.counters["mb_cts"] = size_mb/ctime;
         newfile->Close();
-
         state.ResumeTiming();
     }
 }
 
 static void BM_NanoAOD_Decompress(benchmark::State &state, int algo) {
     int comp_level = state.range(0);
-
+    int nb;
+    TStopwatch timer;
     std::string filename = "level_" + std::to_string(comp_level) + "_nanoaod_" + GetAlgoName(algo) + ".root";
     for (auto _ : state) {
-        TFile *hfile = new TFile(filename.c_str());
-        TTree *tree = (TTree*)hfile->Get("Events");
-
-        Int_t nevent = (Int_t)tree->GetEntries();
-
-        Int_t nb = 0;
+        timer.Start();
+        TFile f(filename.c_str());
+        auto tree = static_cast<TTree *>(f.Get("Events"));
+        const auto nevents = tree->GetEntries();
         Int_t ev;
-
-        for (ev = 0; ev < nevent; ev++) {
+        for (ev = 0; ev < nevents; ++ev) {
             nb += tree->GetEntry(ev);
         }
+        timer.Stop();
+        double rtime = timer.RealTime();
+        double ctime = timer.CpuTime();
+        // For Run2012B_DoubleMuParked.root:
+        float size_mb = 774.619423;
+        // For NanoAOD_DoubleMuon_CMS2011OpenData.root:
+        //float size_mb = 4871.365001;
+        state.counters["mb_rts"] = size_mb/rtime;
+        state.counters["mb_cts"] = size_mb/ctime;
+        f.Close();
     }
 }
 
@@ -94,36 +115,36 @@ static void BM_NanoAOD_Decompress_ZSTD(benchmark::State &state) {
 
 BENCHMARK(BM_NanoAOD_Compress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Compress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Compress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Compress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 
 BENCHMARK(BM_NanoAOD_Decompress_ZLIB)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Decompress_LZMA)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Decompress_LZ4)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 BENCHMARK(BM_NanoAOD_Decompress_ZSTD)
 ->Arg(1)->Arg(6)->Arg(9)
-->Unit(benchmark::kMillisecond)->Iterations(5);
+->Unit(benchmark::kMillisecond)->Iterations(1);
 
 
 BENCHMARK_MAIN();

--- a/root/io/io/TFile_RDFSnapshot.cxx
+++ b/root/io/io/TFile_RDFSnapshot.cxx
@@ -1,14 +1,15 @@
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RSnapshotOptions.hxx"
 #include "TRandom3.h"
+#include "TStopwatch.h"
 
 #include "benchmark/benchmark.h"
 #include "rootbench/RBConfig.h"
 
 
-auto SetupRDF() {
+auto SetupRDF(int size) {
    // We create an empty data frame
-   ROOT::RDataFrame tdf(100000);
+   ROOT::RDataFrame tdf(size);
    // We now fill it with random numbers
    gRandom->SetSeed(1);
    auto tdf_1 = tdf.Define("rnd", []() { return gRandom->Gaus(); });
@@ -24,45 +25,90 @@ auto SetupRDFOptions(ROOT::ECompressionAlgorithm alg, int level) {
 
 
 static void BM_TFile_RDFSnapshot_ZLIB(benchmark::State &state) {
-  auto tdf = SetupRDF();
-  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kZLIB, 1);
+  TStopwatch timer;
+  int size = 50000000;
+  auto tdf = SetupRDF(size);
+  int comp_level = state.range(0);
+  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kZLIB, comp_level);
   for (auto _ : state) {
      //And we write out the dataset on disk
+     timer.Start();
      tdf.Snapshot<double>("randomNumbers", "bench_data.root", {"rnd"}, options);
+     timer.Stop();
+     auto file = TFile::Open("bench_data.root");
+     state.counters["comp_size"] = file->GetSize();
+     double rtime = timer.RealTime();
+     double ctime = timer.CpuTime();
+     state.counters["mb_rts"] = file->GetSize()/rtime;
+     state.counters["mb_cts"] = file->GetSize()/ctime;
   }
 }
-BENCHMARK(BM_TFile_RDFSnapshot_ZLIB)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TFile_RDFSnapshot_ZLIB)->Arg(1)->Arg(6)->Arg(9)->Unit(benchmark::kMicrosecond);
 
 
 static void BM_TFile_RDFSnapshot_LZ4(benchmark::State &state) {
-  auto tdf = SetupRDF();
-  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kLZ4, 4);
+  TStopwatch timer;
+  int size = 50000000;
+  auto tdf = SetupRDF(size);
+  int comp_level = state.range(0);
+  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kLZ4, comp_level);
   for (auto _ : state) {
      //And we write out the dataset on disk
+     timer.Start();
      tdf.Snapshot<double>("randomNumbers", "bench_data.root", {"rnd"}, options);
+     timer.Stop();
+     auto file = TFile::Open("bench_data.root");
+     state.counters["comp_size"] = file->GetSize();
+     double rtime = timer.RealTime();
+     double ctime = timer.CpuTime();
+     state.counters["mb_rts"] = file->GetSize()/rtime;
+     state.counters["mb_cts"] = file->GetSize()/ctime;
   }
 }
-BENCHMARK(BM_TFile_RDFSnapshot_LZ4)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TFile_RDFSnapshot_LZ4)->Arg(1)->Arg(6)->Arg(9)->Unit(benchmark::kMicrosecond);
 
 
 static void BM_TFile_RDFSnapshot_LZMA (benchmark::State &state) {
-  auto tdf = SetupRDF();
-  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kLZMA, 8);
+  TStopwatch timer;
+  int size = 50000000;
+  auto tdf = SetupRDF(size);
+  int comp_level = state.range(0);
+  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kLZMA, comp_level);
   for (auto _ : state) {
      //And we write out the dataset on disk
+     timer.Start();
      tdf.Snapshot<double>("randomNumbers", "bench_data.root", {"rnd"}, options);
+     timer.Stop();
+     auto file = TFile::Open("bench_data.root");
+     state.counters["comp_size"] = file->GetSize();
+     double rtime = timer.RealTime();
+     double ctime = timer.CpuTime();
+     state.counters["mb_rts"] = file->GetSize()/rtime;
+     state.counters["mb_cts"] = file->GetSize()/ctime;
   }
 }
-BENCHMARK(BM_TFile_RDFSnapshot_LZMA)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TFile_RDFSnapshot_LZMA)->Arg(1)->Arg(6)->Arg(9)->Unit(benchmark::kMicrosecond);
+
 
 static void BM_TFile_RDFSnapshot_ZSTD (benchmark::State &state) {
-  auto tdf = SetupRDF();
-  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kZSTD, 6);
+  TStopwatch timer;
+  int size = 50000000;
+  auto tdf = SetupRDF(size);
+  int comp_level = state.range(0);
+  auto options = SetupRDFOptions(ROOT::ECompressionAlgorithm::kZSTD, comp_level);
   for (auto _ : state) {
      //And we write out the dataset on disk
+     timer.Start();
      tdf.Snapshot<double>("randomNumbers", "bench_data.root", {"rnd"}, options);
+     timer.Stop();
+     auto file = TFile::Open("bench_data.root");
+     state.counters["comp_size"] = file->GetSize();
+     double rtime = timer.RealTime();
+     double ctime = timer.CpuTime();
+     state.counters["mb_rts"] = file->GetSize()/rtime;
+     state.counters["mb_cts"] = file->GetSize()/ctime;
   }
 }
-BENCHMARK(BM_TFile_RDFSnapshot_ZSTD)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_TFile_RDFSnapshot_ZSTD)->Arg(1)->Arg(6)->Arg(9)->Arg(20)->Arg(22)->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/root/tree/tree/RNTupleH1Benchmarks.cxx
+++ b/root/tree/tree/RNTupleH1Benchmarks.cxx
@@ -225,10 +225,10 @@ static void BM_TTree_H1(benchmark::State &state, const std::string &comprAlgorit
       delete h2;
    }
 }
-BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1LZ4, "lz4")->Unit(benchmark::kMicrosecond)->Iterations(5);
-BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1ZLIB, "zlib")->Unit(benchmark::kMicrosecond)->Iterations(5);
-BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1LZMA, "lzma")->Unit(benchmark::kMicrosecond)->Iterations(5);
-BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1ZSTD, "zstd")->Unit(benchmark::kMicrosecond)->Iterations(5);
-BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1None, "none")->Unit(benchmark::kMicrosecond)->Iterations(5);
+BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1LZ4, "lz4")->Unit(benchmark::kMicrosecond)->Iterations(3);
+BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1ZLIB, "zlib")->Unit(benchmark::kMicrosecond)->Iterations(3);
+BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1LZMA, "lzma")->Unit(benchmark::kMicrosecond)->Iterations(3);
+BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1ZSTD, "zstd")->Unit(benchmark::kMicrosecond)->Iterations(3);
+BENCHMARK_CAPTURE(BM_TTree_H1, BM_TTree_H1None, "none")->Unit(benchmark::kMicrosecond)->Iterations(3);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
I added a new CMake option: experiment-datafiles - that allows to download experiments files (CMS, ATLAS) that are bigger then 1.5 GB

I also used these benchmarks for testing FLZMA2 (suggestions are welcomed!)