### PR TITLE
Bump google benchmark version to 1.5.5

### DIFF
--- a/cmake/modules/GoogleBenchmark.cmake
+++ b/cmake/modules/GoogleBenchmark.cmake
@@ -9,7 +9,7 @@ set(GBENCHMARK_LIBRARY_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}benchmark${CMAKE_STATI
 ExternalProject_Add(
   googlebenchmark
   GIT_REPOSITORY https://github.com/google/benchmark.git
-  GIT_TAG v1.5.0
+  GIT_TAG v1.5.5
   UPDATE_COMMAND ""
   # TIMEOUT 10
   # # Force separate output paths for debug and release builds to allow easy


### PR DESCRIPTION
In particular this fixes a compilation error in gbench with recent
gcc versions by adding a missing include in `benchmark_register.h`.