### PR TITLE
Fix error "'::timespec_get' has not been declared" by updating conda-fo…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Conda install dependencies
       shell: bash -l {0}
       run: |
-           conda create -n root-nightly -y -c https://root.cern/download/conda-nightly/latest -c conda-forge root-nightly cmake pytest pytest-benchmark pytest-csv numpy numba
+           conda create -n root-nightly -y -c https://root.cern/download/conda-nightly/latest -c conda-forge root-nightly gcc_linux-64 cmake pytest pytest-benchmark pytest-csv numpy numba
 
     - name: Configure and build
       shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,11 @@ jobs:
       shell: bash -l {0}
       run: conda info
 
-    - name: "Init conda"
+    - name: "Init/upgrade conda"
       shell: bash -l {0}
       run: |
           conda init bash
+          conda upgrade -c conda-forge --all
 
     - name: Conda install dependencies
       shell: bash -l {0}


### PR DESCRIPTION
…rge channels

Possible fix was discussed here: https://root-forum.cern.ch/t/error-timespec-get-has-not-been-declared-with-conda-root-package/45712/8