### PR TITLE
[ntuple] Minor fix required after merging RNTuple binary format v1

### DIFF
--- a/root/tree/tree/RNTupleH1Benchmarks.cxx
+++ b/root/tree/tree/RNTupleH1Benchmarks.cxx
@@ -41,11 +41,11 @@ static void BM_RNTuple_H1(benchmark::State &state, const std::string &comprAlgor
    auto ipisView = ntuple->GetView<std::int32_t>("event.ipis");
    auto md0_dView = ntuple->GetView<float>("event.md0_d");
    auto trackView = ntuple->GetViewCollection("event.tracks");
-   auto nhitrpView = ntuple->GetView<std::int32_t>("event.tracks.H1Event::Track.nhitrp");
-   auto rstartView = ntuple->GetView<float>("event.tracks.H1Event::Track.rstart");
-   auto rendView = ntuple->GetView<float>("event.tracks.H1Event::Track.rend");
-   auto nlhkView = ntuple->GetView<float>("event.tracks.H1Event::Track.nlhk");
-   auto nlhpiView = ntuple->GetView<float>("event.tracks.H1Event::Track.nlhpi");
+   auto nhitrpView = ntuple->GetView<std::int32_t>("event.tracks._0.nhitrp");
+   auto rstartView = ntuple->GetView<float>("event.tracks._0.rstart");
+   auto rendView = ntuple->GetView<float>("event.tracks._0.rend");
+   auto nlhkView = ntuple->GetView<float>("event.tracks._0.nlhk");
+   auto nlhpiView = ntuple->GetView<float>("event.tracks._0.nlhpi");
    auto njetsView = ntuple->GetViewCollection("event.jets");
    // Check print info (minitest)
    std::ostringstream os;


### PR DESCRIPTION
According to RNTuple binary format v1 specification, [section std::vector<T> and ROOT::RVec<T>](https://github.com/root-project/root/blob/master/tree/ntuple/v7/doc/specifications.md#stdvector-and-rootrvec), the name of the child field of a `std::vector<T>` is now `_0`.

This PR fixes the dot-path in RNTupleH1Benchmarks.