### PR TITLE
[RF] Link vectorisedPDFs benchmarks with RooBatchCompute

### DIFF
--- a/root/roofit/vectorisedPDFs/CMakeLists.txt
+++ b/root/roofit/vectorisedPDFs/CMakeLists.txt
@@ -1,13 +1,13 @@
 RB_ADD_GBENCHMARK(benchAddPdf
   benchAddPdf.cxx
   LABEL long
-  LIBRARIES Core MathCore RooFitCore RooFit)
+  LIBRARIES Core MathCore RooFitCore RooFit RooBatchCompute)
 RB_ADD_GBENCHMARK(benchGauss
   benchGauss.cxx
   LABEL long
-  LIBRARIES Core MathCore RooFitCore RooFit)
+  LIBRARIES Core MathCore RooFitCore RooFit RooBatchCompute)
 RB_ADD_GBENCHMARK(benchJohnson
   benchJohnson.cxx
   LABEL long
-  LIBRARIES Core MathCore RooFitCore RooFit)
+  LIBRARIES Core MathCore RooFitCore RooFit RooBatchCompute)
 


### PR DESCRIPTION
This makes `rootbench` build again with the ROOT master.