### PR TITLE
Fix CI hanging at GenVector benchmark

### DIFF
--- a/root/math/genvector/Cartesian3DBenchmarks.cxx
+++ b/root/math/genvector/Cartesian3DBenchmarks.cxx
@@ -25,7 +25,7 @@ static void BM_Cartesian3D_Sanity(benchmark::State &state)
   }
 #endif
 }
-BENCHMARK(BM_Cartesian3D_Sanity);
+BENCHMARK(BM_Cartesian3D_Sanity)->Iterations(1);
 
 static void BM_Cartesian3D_CreateEmpty(benchmark::State &state)
 {


### PR DESCRIPTION
I am not sure exactly why, but with the empty payload of
BM_Cartesian3D_Sanity google benchmark seems to enter an
infinite loop here:
https://github.com/google/benchmark/blob/d0fbf8ac238d3bc3a111334ab3553173812d78e7/src/benchmark_runner.cc#L280-L303

In principle gbench should exit the loop after a certain maximum
number of iterations, but it doesn't seem to happen, or for some
reason it takes way too much time.

In any case, as this benchmark is actually just a hack to inject a
sanity check, we might as well set it to run only 1 iteration.