### PR TITLE
Import header-only library to read/write simple HEP data in HDF5

### DIFF
--- a/root/tree/tree/h5hep/README.md
+++ b/root/tree/tree/h5hep/README.md
@@ -1,35 +1,107 @@
-# h5hep: header-only library to read/write high-energy physics data in HDF5
-This code is for benchmark purposes only; do NOT use in production.
+# h5hep: (unsupported, unofficial) header-only library to read/write high-energy physics data in HDF5
+THIS CODE IS FOR BENCHMARK PURPOSES ONLY; DO NOT USE IN PRODUCTION.
 
-Example of use:
-```c++
-#include <h5hep/h5hep.hxx>
+h5hep allows the storage of simple HEP data in HDF5, hiding away the details of data representation. Currently, it supports two different column models:
 
-struct Bar {
-  float f1;
-  float f2;
-};
+- COMPOUND_TYPE: that uses (possibly nested) compound types to represent data for each row.
 
-struct Foo {
-  int i;
-  float f;
-  h5hep::Collection<Bar> c;
-};
+- COLUMNAR_FNAL: uses one HDF5 dataset per primitive column. Collections are translated to a HDF5 group and an index column. For more information, see [this](https://inspirehep.net/files/e048b0cd122919dc9a009793983a81e0) publication.
 
-int main(int argc, char *argv[]) {
-  using Builder = h5hep::schema::SchemaBuilder<h5hep::ColumnModel::COMPOUND_TYPE>;
-  
-  auto root = Builder::MakeStructNode<Foo>("Foo", {
-      Builder::MakePrimitiveNode<int>("i", HOFFSET(Foo, i)),
-      Builder::MakePrimitiveNode<float>("f", HOFFSET(Foo, f)),
-      Builder::MakeCollectionNode("c", HOFFSET(Foo, c),
-				  Builder::MakeStructNode<Bar>("Bar", {
-				      Builder::MakePrimitiveNode<float>("f1", HOFFSET(Bar, f1)),
-				      Builder::MakePrimitiveNode<float>("f2", HOFFSET(Bar, f2)),
-				    })),
-    });
+## Example
+The Makefile in the examples/ directory generates two versions of [simple_struct.cxx](https://github.com/jalopezg-r00t/h5hep/blob/root/tree/tree/h5hep/master/examples/simple_struct.cxx): `simple_struct_compound` and `simple_struct_fnal`. As seen below, both generate the same output:
+```bash
+$ ./simple_struct_compound
+i=0 f=1.2345
+i=1 f=2.2345
+i=2 f=3.2345
+i=3 f=4.2345
+$ ./simple_struct_fnal
+i=0 f=1.2345
+i=1 f=2.2345
+i=2 f=3.2345
+i=3 f=4.2345
+```
 
-  // ...
-  return 0;
+However, the HDF5 representation of the schema and user data is completely different:
+```bash
+$ # For ./simple_struct_compound
+$ h5dump simple_struct.h5
+HDF5 "simple_struct.h5" {
+GROUP "/" {
+   DATASET "Foo" {
+      DATATYPE  H5T_COMPOUND {
+         H5T_STD_I32LE "i";
+         H5T_IEEE_F32LE "f";
+         H5T_VLEN { H5T_COMPOUND {
+            H5T_IEEE_F32LE "f1";
+            H5T_IEEE_F32LE "f2";
+         }} "c";
+      }
+      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
+      DATA {
+      (0): {
+            0,
+            1.2345,
+            ({
+                  1.1,
+                  1.2
+               }, {
+                  2.1,
+                  2.2
+               }, {
+                  3.1,
+                  3.2
+               })
+         },
+...
+$ # For ./simple_struct_fnal
+$ h5dump simple_struct.h5
+HDF5 "simple_struct.h5" {
+GROUP "/" {
+   ATTRIBUTE "$Metadata" {
+      DATATYPE  H5T_STD_U64LE
+      DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
+      DATA {
+      (0): 4, 4
+      }
+   }
+   GROUP "c" {
+      DATASET "Event ID" {
+         DATATYPE  H5T_STD_U64LE
+         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
+         DATA {
+         (0): 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3
+         }
+      }
+      DATASET "f1" {
+         DATATYPE  H5T_IEEE_F32LE
+         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
+         DATA {
+         (0): 1.1, 2.1, 3.1, 1.1, 2.1, 3.1, 1.1, 2.1, 3.1, 1.1, 2.1, 3.1
+         }
+      }
+      DATASET "f2" {
+         DATATYPE  H5T_IEEE_F32LE
+         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
+         DATA {
+         (0): 1.2, 2.2, 3.2, 1.2, 2.2, 3.2, 1.2, 2.2, 3.2, 1.2, 2.2, 3.2
+         }
+      }
+   }
+   DATASET "f" {
+      DATATYPE  H5T_IEEE_F32LE
+      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
+      DATA {
+      (0): 1.2345, 2.2345, 3.2345, 4.2345
+      }
+   }
+   DATASET "i" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
+      DATA {
+      (0): 0, 1, 2, 3
+      }
+   }
+}
 }
 ```

--- a/root/tree/tree/h5hep/README.md
+++ b/root/tree/tree/h5hep/README.md
@@ -1,0 +1,35 @@
+# h5hep: header-only library to read/write high-energy physics data in HDF5
+This code is for benchmark purposes only; do NOT use in production.
+
+Example of use:
+```c++
+#include <h5hep/h5hep.hxx>
+
+struct Bar {
+  float f1;
+  float f2;
+};
+
+struct Foo {
+  int i;
+  float f;
+  h5hep::Collection<Bar> c;
+};
+
+int main(int argc, char *argv[]) {
+  using Builder = h5hep::schema::SchemaBuilder<h5hep::ColumnModel::COMPOUND_TYPE>;
+  
+  auto root = Builder::MakeStructNode<Foo>("Foo", {
+      Builder::MakePrimitiveNode<int>("i", HOFFSET(Foo, i)),
+      Builder::MakePrimitiveNode<float>("f", HOFFSET(Foo, f)),
+      Builder::MakeCollectionNode("c", HOFFSET(Foo, c),
+				  Builder::MakeStructNode<Bar>("Bar", {
+				      Builder::MakePrimitiveNode<float>("f1", HOFFSET(Bar, f1)),
+				      Builder::MakePrimitiveNode<float>("f2", HOFFSET(Bar, f2)),
+				    })),
+    });
+
+  // ...
+  return 0;
+}
+```

--- a/root/tree/tree/h5hep/examples/Makefile
+++ b/root/tree/tree/h5hep/examples/Makefile
@@ -1,0 +1,13 @@
+CFLAGS=-std=c++17 -O2 -Wall -I..
+LDFLAGS=-lhdf5
+
+all: simple_struct_compound simple_struct_fnal
+
+clean:
+	rm -f simple_struct_compound simple_struct_fnal simple_struct.h5
+
+simple_struct_compound: simple_struct.cxx
+	g++ $(CFLAGS) $(LDFLAGS) -D__COLUMN_MODEL__=h5hep::ColumnModel::COMPOUND_TYPE -o $@ $^
+
+simple_struct_fnal: simple_struct.cxx
+	g++ $(CFLAGS) $(LDFLAGS) -D__COLUMN_MODEL__=h5hep::ColumnModel::COLUMNAR_FNAL -o $@ $^

--- a/root/tree/tree/h5hep/examples/simple_struct.cxx
+++ b/root/tree/tree/h5hep/examples/simple_struct.cxx
@@ -1,0 +1,61 @@
+#include <h5hep/h5hep.hxx>
+#include <iostream>
+
+struct Bar {
+  float f1;
+  float f2;
+};
+
+struct Foo {
+  int i;
+  float f;
+  h5hep::Collection<Bar> c;
+};
+
+int main(int argc, char *argv[]) {
+  using Builder = h5hep::schema::SchemaBuilder<__COLUMN_MODEL__>;
+  {
+    auto root = Builder::MakeStructNode<Foo>("Foo", {
+	Builder::MakePrimitiveNode<int>("i", HOFFSET(Foo, i)),
+	Builder::MakePrimitiveNode<float>("f", HOFFSET(Foo, f)),
+	Builder::MakeCollectionNode("c", HOFFSET(Foo, c),
+				    Builder::MakeStructNode<Bar>("Bar", {
+					Builder::MakePrimitiveNode<float>("f1", HOFFSET(Bar, f1)),
+					Builder::MakePrimitiveNode<float>("f2", HOFFSET(Bar, f2)),
+				      })),
+      });
+
+    h5hep::WriteProperties props;
+    props.SetChunkSize(4);
+    props.SetCompressionLevel(0);
+    auto file = h5hep::H5File::Create("simple_struct.h5");
+    auto rw = Builder::MakeReaderWriter(file, root, props);
+
+    Foo chunk[4]{};
+    std::vector<Bar> v{{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
+    for (size_t i = 0; i < 4; ++i) {
+      chunk[i].i = i;
+      chunk[i].f = i + 1.2345f;
+      chunk[i].c = v;
+    }
+    rw->WriteChunk(0, chunk);
+  }
+
+  {
+    // The schema for reading selects only a few columns
+    auto root = Builder::MakeStructNode<Foo>("Foo", {
+	Builder::MakePrimitiveNode<int>("i", HOFFSET(Foo, i)),
+	Builder::MakePrimitiveNode<float>("f", HOFFSET(Foo, f)),
+      });
+
+    auto file = h5hep::H5File::Open("simple_struct.h5");
+    auto rw = Builder::MakeReaderWriter(file, root);
+
+    Foo chunk[4]{};
+    rw->ReadChunk(0, chunk);
+    for (size_t i = 0; i < 4; ++i) {
+      std::cout << "i=" << chunk[i].i << " f=" << chunk[i].f << std::endl;
+    }
+  }
+  return 0;
+}

--- a/root/tree/tree/h5hep/h5hep/common.hxx
+++ b/root/tree/tree/h5hep/h5hep/common.hxx
@@ -63,7 +63,7 @@ namespace h5hep {
     Collection() : CollectionBase({}, nullptr) {}
     Collection(const Collection<T> &c) : CollectionBase(hvl_t{c.size(), c.data()}, nullptr) {}
     Collection(std::vector<T> &v) : CollectionBase(hvl_t{v.size(), v.data()}, nullptr) {}
-    Collection(const void *data, size_t size, Deleter_t d = nullptr) : CollectionBase(hvl_t{size, data}, d) {}
+    Collection(void *data, size_t size, Deleter_t d = nullptr) : CollectionBase(hvl_t{size, data}, d) {}
 
     Collection<T> &operator=(Collection<T> &&other) {
       std::swap(hvl, other.hvl);

--- a/root/tree/tree/h5hep/h5hep/common.hxx
+++ b/root/tree/tree/h5hep/h5hep/common.hxx
@@ -24,8 +24,8 @@
 #endif
 
 /// \brief Iterate over each row described by a `std::vector<Span>`
-#define for_each_row_in_extentlist(__Es, __E, __i)	\
-  for (auto &__E : (__Es))				\
+#define for_each_row_in_extentlist(__Es, __E, __i)        \
+  for (auto &__E : (__Es))                                \
     for (size_t __i = 0; i < __E.len; ++i)
 
 namespace h5hep {
@@ -111,7 +111,7 @@ namespace h5hep {
   constexpr hid_t GetH5TypeId() {
     using U = typename std::decay<T>::type;
     static_assert(!std::is_pointer<U>::value && !std::is_reference<U>::value,
-		  "Pointer/references currently not supported");
+                  "Pointer/references currently not supported");
 
     if constexpr (std::is_same<U, char>::value) return H5T_NATIVE_SCHAR;
     if constexpr (std::is_same<U, unsigned char>::value) return H5T_NATIVE_UCHAR;

--- a/root/tree/tree/h5hep/h5hep/common.hxx
+++ b/root/tree/tree/h5hep/h5hep/common.hxx
@@ -1,0 +1,140 @@
+/// \file h5hep/common.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-10-23
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+
+#ifndef _H5HEP_COMMON_HXX
+#define _H5HEP_COMMON_HXX
+
+#include <hdf5.h>
+
+#include <cassert>
+#include <type_traits>
+#include <vector>
+
+#if defined(__GNUC__)
+# define likely(x)   __builtin_expect(!!(x), 1)
+# define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+# define likely(x)   x
+# define unlikely(x) x
+# define __restrict
+#endif
+
+/// \brief Iterate over each row described by a `std::vector<Span>`
+#define for_each_row_in_extentlist(__Es, __E, __i)	\
+  for (auto &__E : (__Es))				\
+    for (size_t __i = 0; i < __E.len; ++i)
+
+namespace h5hep {
+
+  struct CollectionBase {
+    using Deleter_t = void (*)(void *p, void *privateData);
+    hvl_t hvl{}; // Must appear first!
+    Deleter_t deleter{};
+    void *privateData;
+
+    CollectionBase() = default;
+    CollectionBase(const hvl_t &hvl, Deleter_t d) : hvl{hvl.len, hvl.p}, deleter(d) {}
+    ~CollectionBase() { invokeDeleter(); }
+
+    void invokeDeleter() { if (hvl.p && deleter) deleter(hvl.p, privateData); }
+    void assign(const hvl_t &hvl, Deleter_t d, void *privateData = nullptr) {
+      invokeDeleter();
+      this->hvl = hvl_t{hvl.len, hvl.p};
+      this->deleter = d;
+      this->privateData = privateData;
+    }
+  };
+
+  /// \brief Variable-length collection of elements of type `T`. Might be used
+  /// as part of a larger data type to annotate a collection, e.g.
+  /// ```
+  /// struct Foo {
+  ///   float f;
+  ///   h5hep::Collection<int> i;
+  /// };
+  /// ```
+  template <typename T>
+  struct Collection : public CollectionBase {
+  public:
+    Collection() : CollectionBase({}, nullptr) {}
+    Collection(const Collection<T> &c) : CollectionBase(hvl_t{c.size(), c.data()}, nullptr) {}
+    Collection(std::vector<T> &v) : CollectionBase(hvl_t{v.size(), v.data()}, nullptr) {}
+
+    Collection<T> &operator=(Collection<T> &&other) {
+      std::swap(hvl.len, other.size());
+      std::swap(hvl.p, other.data());
+      std::swap(deleter, other.deleter);
+      std::swap(privateData, other.privateData);
+      return *this;
+    }
+
+    Collection<T> &operator=(const Collection<T> &other) {
+      assign(other.hvl, nullptr);
+      return *this;
+    }
+
+    Collection<T> &operator=(std::vector<T> &other) {
+      assign(hvl_t{other.size(), other.data()}, nullptr);
+      return *this;
+    }
+
+    size_t size() const { return hvl.len; }
+    T *data() { return static_cast<T*>(hvl.p); }
+    T &operator[](size_t i) { return data()[i]; }
+  };
+
+  /// \brief A span of size `len` starting at `offset`.
+  struct Span {
+    size_t offset;
+    size_t len;
+  };
+
+  /// \brief A HDF5 span type which might be used by column models as index into a collection.
+  struct H5Span_t {
+    hid_t typeId;
+    H5Span_t() {
+      typeId = H5Tcreate(H5T_COMPOUND, sizeof(Span));
+      assert(typeId != H5I_INVALID_HID && "Could not create H5Span compound type");
+      H5Tinsert(typeId, "offset", HOFFSET(Span, offset), H5T_NATIVE_ULONG);
+      H5Tinsert(typeId, "len", HOFFSET(Span, len), H5T_NATIVE_ULONG);
+    }
+    ~H5Span_t() { H5Tclose(typeId); }
+  };
+  static H5Span_t H5Span{};
+
+  /// \brief Translate the C++ type `T` into a HDF5 type.
+  template <typename T>
+  constexpr hid_t GetH5TypeId() {
+    using U = typename std::decay<T>::type;
+    static_assert(!std::is_pointer<U>::value && !std::is_reference<U>::value,
+		  "Pointer/references currently not supported");
+
+    if constexpr (std::is_same<U, char>::value) return H5T_NATIVE_SCHAR;
+    if constexpr (std::is_same<U, unsigned char>::value) return H5T_NATIVE_UCHAR;
+    if constexpr (std::is_same<U, short>::value) return H5T_NATIVE_SHORT;
+    if constexpr (std::is_same<U, unsigned short>::value) return H5T_NATIVE_USHORT;
+    if constexpr (std::is_same<U, int>::value) return H5T_NATIVE_INT;
+    if constexpr (std::is_same<U, unsigned int>::value) return H5T_NATIVE_UINT;
+    if constexpr (std::is_same<U, long>::value) return H5T_NATIVE_LONG;
+    if constexpr (std::is_same<U, unsigned long>::value) return H5T_NATIVE_ULONG;
+    if constexpr (std::is_same<U, long long>::value) return H5T_NATIVE_LLONG;
+    if constexpr (std::is_same<U, unsigned long long>::value) return H5T_NATIVE_ULLONG;
+    if constexpr (std::is_same<U, float>::value) return H5T_NATIVE_FLOAT;
+    if constexpr (std::is_same<U, double>::value) return H5T_NATIVE_DOUBLE;
+    if constexpr (std::is_same<U, bool>::value) return H5T_NATIVE_HBOOL;
+    return H5I_INVALID_HID;
+  }
+
+  namespace internal {
+    hsize_t zero[] = {0};
+    hsize_t one[] = {1};
+    hsize_t unlimited[] = {H5S_UNLIMITED};
+  } // namespace internal
+
+} // namespace h5hep
+
+#endif // _H5HEP_COMMON_HXX

--- a/root/tree/tree/h5hep/h5hep/common.hxx
+++ b/root/tree/tree/h5hep/h5hep/common.hxx
@@ -63,10 +63,10 @@ namespace h5hep {
     Collection() : CollectionBase({}, nullptr) {}
     Collection(const Collection<T> &c) : CollectionBase(hvl_t{c.size(), c.data()}, nullptr) {}
     Collection(std::vector<T> &v) : CollectionBase(hvl_t{v.size(), v.data()}, nullptr) {}
+    Collection(const void *data, size_t size, Deleter_t d = nullptr) : CollectionBase(hvl_t{size, data}, d) {}
 
     Collection<T> &operator=(Collection<T> &&other) {
-      std::swap(hvl.len, other.size());
-      std::swap(hvl.p, other.data());
+      std::swap(hvl, other.hvl);
       std::swap(deleter, other.deleter);
       std::swap(privateData, other.privateData);
       return *this;

--- a/root/tree/tree/h5hep/h5hep/h5hep.hxx
+++ b/root/tree/tree/h5hep/h5hep/h5hep.hxx
@@ -1,0 +1,17 @@
+/// \file h5hep/h5hep.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-11-13
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+
+#ifndef _H5HEP_H5HEP_HXX
+#define _H5HEP_H5HEP_HXX
+
+#include <h5hep/common.hxx>
+#include <h5hep/schema.hxx>
+#include <h5hep/io.hxx>
+#include <h5hep/model_compoundtype.hxx>
+#include <h5hep/model_columnarfnal.hxx>
+
+#endif // _H5HEP_H5HEP_HXX

--- a/root/tree/tree/h5hep/h5hep/io.hxx
+++ b/root/tree/tree/h5hep/h5hep/io.hxx
@@ -1,0 +1,240 @@
+/// \file h5hep/io.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-11-05
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+
+#ifndef _H5HEP_IO_HXX
+#define _H5HEP_IO_HXX
+
+#include <h5hep/common.hxx>
+#include <h5hep/schema.hxx>
+
+#include <hdf5.h>
+
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+namespace h5hep {
+
+  namespace internal {
+    /// \brief Given `extents`, determine the minimum dataset size required to satisfy a R/W operation
+    static inline size_t GetMinimumDatasetSize(const std::vector<Span> &extents) {
+      return std::accumulate(extents.begin(), extents.end(), 0,
+			     [] (size_t a, const Span &b) { return std::max(a, (b.offset + b.len)); });
+    }
+
+    static inline hsize_t GetDataspaceSize(hid_t spaceId) {
+      hsize_t ret;
+      H5Sget_simple_extent_dims(spaceId, &ret, NULL);
+      return ret;
+    }
+
+    /// \brief Reference implementation of `ReadExtents()`. Column models may call this as part of
+    /// `XxxNode::ReadExtents()`. Data for each entry in `extents` is copied contiguously in `buf`.
+    static inline size_t SimpleReadExtents(const std::vector<Span> &extents, void *buf,
+					   hid_t datasetId, hid_t spaceId, hid_t typeId) {
+      const size_t dataspaceSize = GetDataspaceSize(spaceId);
+      auto p = reinterpret_cast<unsigned char*>(buf);
+      size_t count = 0;
+      size_t sz = H5Tget_size(typeId);
+
+      for (const auto &E : extents) {
+	hsize_t start[] = {E.offset};
+	hsize_t block[] = {E.len};
+	if (E.offset >= dataspaceSize)
+	  continue;
+	if (E.offset + E.len > dataspaceSize)
+	  block[0] = dataspaceSize - E.offset;
+
+	auto mspace = H5Screate_simple(1, block, NULL);
+	H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
+			    /*count=*/internal::one, block);
+	H5Dread(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
+	H5Sclose(mspace);
+	p += (block[0] * sz);
+	count += block[0];
+      }
+      return count;
+    }
+
+    /// \brief Reference implementation of `WriteExtents()`. Column models may call this as part of
+    /// `XxxNode::WriteExtents()`.
+    static inline size_t SimpleWriteExtents(const std::vector<Span> &extents, const void *buf,
+					    hid_t datasetId, hid_t &spaceId, hid_t typeId) {
+      const auto requiredSize = GetMinimumDatasetSize(extents);
+      auto p = reinterpret_cast<const unsigned char*>(buf);
+      size_t count = 0;
+      size_t sz = H5Tget_size(typeId);
+
+      if (requiredSize > GetDataspaceSize(spaceId)) {
+	hsize_t newSize[] = {requiredSize};
+	H5Sclose(spaceId);
+	H5Dset_extent(datasetId, newSize);
+	spaceId = H5Dget_space(datasetId);
+      }
+
+      for (const auto &E : extents) {
+	hsize_t start[] = {E.offset};
+	hsize_t block[] = {E.len};
+
+	auto mspace = H5Screate_simple(1, block, NULL);
+	H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
+			    /*count=*/internal::one, block);
+	H5Dwrite(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
+	H5Sclose(mspace);
+	p += (block[0] * sz);
+	count += block[0];
+      }
+      return count;
+    }
+
+    /// \brief Copies `n` elements of size `sz` from `src` to `dest`. The strides that separate
+    /// elements in `dest` and `src` is given by `stride_dest` and `stride_src`, respectively.
+    /// This function is mostly used to copy to/from column buffers.
+    static inline void CopyElements(void *__restrict dest, const void *__restrict src, size_t n,
+				    size_t sz, size_t stride_dest, size_t stride_src) {
+      auto _dest = reinterpret_cast<unsigned char*>(dest);
+      auto _src = reinterpret_cast<const unsigned char*>(src);
+      for (size_t i = 0; i < n; ++i) {
+	memcpy(_dest, _src, sz);
+	_dest += stride_dest;
+	_src += stride_src;
+      }
+    }
+  } // namespace internal
+
+  class H5Location {
+  protected:
+    hid_t hid = H5I_INVALID_HID;
+    H5Location(hid_t hid) : hid(hid) {}
+  public:
+    hid_t GetHandle() const { return hid; }
+  };
+
+  class H5File : public H5Location {
+    hid_t accessPlist;
+
+    H5File(hid_t hid) : H5Location(hid) { accessPlist = H5Fget_access_plist(hid); }
+  public:
+    H5File() = delete;
+    ~H5File() {
+      H5Pclose(accessPlist);
+      H5Fclose(hid);
+    }
+
+    /// \brief Set HDF5 chunk cache parameters. For the specific meaning of each parameter, see
+    /// https://support.hdfgroup.org/HDF5/doc1.8/RM/RM_H5P.html
+    void SetCache(size_t rdcc_nbytes, size_t rdcc_nslots = 521, double rdcc_w0 = 0.75)
+    { H5Pset_cache(accessPlist, /*mdc_nelmts=*/0, rdcc_nbytes, rdcc_nslots, rdcc_w0); }
+
+    static std::shared_ptr<H5Location> Create(std::string_view path, unsigned flags = H5F_ACC_TRUNC) {
+      auto fileId = H5Fcreate(path.data(), flags, H5P_DEFAULT, H5P_DEFAULT);
+      if (fileId == H5I_INVALID_HID)
+	throw std::runtime_error("H5Fcreate error");
+      return std::shared_ptr<H5Location>(new H5File(fileId));
+    }
+
+    static std::shared_ptr<H5Location> Open(std::string_view path, unsigned flags = H5F_ACC_RDONLY) {
+      auto fileId = H5Fopen(path.data(), flags, H5P_DEFAULT);
+      if (fileId == H5I_INVALID_HID)
+	throw std::runtime_error("H5Fopen error");
+      return std::shared_ptr<H5Location>(new H5File(fileId));
+    }
+  };
+
+  /// \brief Properties used by `ReaderWriter` to generate HDF5 datasets
+  class WriteProperties {
+    size_t chunkSize = 10000;
+    unsigned compressionLevel = 0;
+  public:
+    WriteProperties() = default;
+    WriteProperties(const WriteProperties &) = default;
+    WriteProperties(size_t s, unsigned l) : chunkSize(s), compressionLevel(l) {}
+
+    size_t GetChunkSize() const { return chunkSize; }
+    void SetChunkSize(const size_t val) { chunkSize = val; }
+
+    unsigned GetCompressionLevel() const { return compressionLevel; }
+    void SetCompressionLevel(const unsigned val) { compressionLevel = val; }
+  };
+
+  class ReaderWriter {
+  protected:
+    std::shared_ptr<H5Location> location;
+    std::shared_ptr<schema::NodeBase> root; /// \brief Root node of the schema
+    std::vector<size_t> collectionIdxs; /// \brief Indices of top-level collections in `root`
+    WriteProperties props;
+    hid_t dcpl = H5I_INVALID_HID; /// \brief Dataset creation property list built from `props`
+
+    /// Dataspace and dataset identifiers, if the column model uses a single dataset
+    hid_t spaceId = H5I_INVALID_HID;
+    hid_t datasetId = H5I_INVALID_HID;
+
+    void RealizeSchema(void *privateData = nullptr) {
+      for (size_t i = 0; i < root->children.size(); ++i) {
+	if (root->children[i]->kind == schema::NodeKind::COLLECTION)
+	  collectionIdxs.push_back(i);
+      }
+      root->Realize(*this, privateData);
+    }
+
+    /// \brief Initialize top-level collections in the row group pointed to by `buf`. This should
+    /// trigger the recursive deallocation of owned `hvl_t` buffers.
+    virtual void InitializeCollections(const std::vector<Span> &extents, void *buf) const {
+      auto p = reinterpret_cast<unsigned char*>(buf);
+      for_each_row_in_extentlist(extents, E, i) {
+	for (size_t j : collectionIdxs) {
+	  const auto &C = root->children[j];
+	  C->InitializeValue(p + C->offset);
+	}
+	p += root->size;
+      }
+    }
+
+  public:
+    ReaderWriter(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot)
+      : location(location), root(schemaRoot->Clone()) {}
+    ReaderWriter(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot,
+		 const WriteProperties &props)
+      : location(location), root(schemaRoot->Clone()), props(props) {}
+    virtual ~ReaderWriter() {}
+
+    std::shared_ptr<schema::NodeBase> GetSchemaRoot() const { return root; }
+    const WriteProperties &GetWriteProperties() const { return props; }
+
+    /// \brief Get the number of entries in this n-tuple
+    virtual size_t GetNEntries() const = 0;
+
+    /// \brief Get the number of chunks (row groups)
+    size_t GetNChunks() const {
+      const auto chunkSize = props.GetChunkSize();
+      return (GetNEntries() + chunkSize - 1) / chunkSize;
+    }
+
+    /// \brief For column models using a single dataset, return the dataspace identifier
+    hid_t GetSpaceId() const { return spaceId; }
+    hid_t GetDatasetId() const { return datasetId; }
+
+    virtual size_t ReadExtents(const std::vector<Span> &extents, void *buf)
+    { return root->ReadExtents(extents, buf); }
+    virtual size_t WriteExtents(const std::vector<Span> &extents, const void *buf)
+    { return root->WriteExtents(extents, buf); }
+
+    size_t ReadChunk(size_t n, void *buf)
+    { return ReadExtents(std::vector<Span>{{n * props.GetChunkSize(), props.GetChunkSize()}}, buf); }
+
+    size_t WriteChunk(size_t n, void *buf, size_t size)
+    { return WriteExtents(std::vector<Span>{{n * props.GetChunkSize(), size}}, buf); }
+    size_t WriteChunk(size_t n, void *buf)
+    { return WriteChunk(n, buf, props.GetChunkSize()); }
+  };
+
+} // namespace h5hep
+
+#endif // _H5HEP_IO_HXX

--- a/root/tree/tree/h5hep/h5hep/io.hxx
+++ b/root/tree/tree/h5hep/h5hep/io.hxx
@@ -26,7 +26,7 @@ namespace h5hep {
     /// \brief Given `extents`, determine the minimum dataset size required to satisfy a R/W operation
     static inline size_t GetMinimumDatasetSize(const std::vector<Span> &extents) {
       return std::accumulate(extents.begin(), extents.end(), 0,
-			     [] (size_t a, const Span &b) { return std::max(a, (b.offset + b.len)); });
+                             [] (size_t a, const Span &b) { return std::max(a, (b.offset + b.len)); });
     }
 
     static inline hsize_t GetDataspaceSize(hid_t spaceId) {
@@ -38,27 +38,27 @@ namespace h5hep {
     /// \brief Reference implementation of `ReadExtents()`. Column models may call this as part of
     /// `XxxNode::ReadExtents()`. Data for each entry in `extents` is copied contiguously in `buf`.
     static inline size_t SimpleReadExtents(const std::vector<Span> &extents, void *buf,
-					   hid_t datasetId, hid_t spaceId, hid_t typeId) {
+                                           hid_t datasetId, hid_t spaceId, hid_t typeId) {
       const size_t dataspaceSize = GetDataspaceSize(spaceId);
       auto p = reinterpret_cast<unsigned char*>(buf);
       size_t count = 0;
       size_t sz = H5Tget_size(typeId);
 
       for (const auto &E : extents) {
-	hsize_t start[] = {E.offset};
-	hsize_t block[] = {E.len};
-	if (E.offset >= dataspaceSize)
-	  continue;
-	if (E.offset + E.len > dataspaceSize)
-	  block[0] = dataspaceSize - E.offset;
+        hsize_t start[] = {E.offset};
+        hsize_t block[] = {E.len};
+        if (E.offset >= dataspaceSize)
+          continue;
+        if (E.offset + E.len > dataspaceSize)
+          block[0] = dataspaceSize - E.offset;
 
-	auto mspace = H5Screate_simple(1, block, NULL);
-	H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
-			    /*count=*/internal::one, block);
-	H5Dread(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
-	H5Sclose(mspace);
-	p += (block[0] * sz);
-	count += block[0];
+        auto mspace = H5Screate_simple(1, block, NULL);
+        H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
+                            /*count=*/internal::one, block);
+        H5Dread(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
+        H5Sclose(mspace);
+        p += (block[0] * sz);
+        count += block[0];
       }
       return count;
     }
@@ -66,30 +66,30 @@ namespace h5hep {
     /// \brief Reference implementation of `WriteExtents()`. Column models may call this as part of
     /// `XxxNode::WriteExtents()`.
     static inline size_t SimpleWriteExtents(const std::vector<Span> &extents, const void *buf,
-					    hid_t datasetId, hid_t &spaceId, hid_t typeId) {
+                                            hid_t datasetId, hid_t &spaceId, hid_t typeId) {
       const auto requiredSize = GetMinimumDatasetSize(extents);
       auto p = reinterpret_cast<const unsigned char*>(buf);
       size_t count = 0;
       size_t sz = H5Tget_size(typeId);
 
       if (requiredSize > GetDataspaceSize(spaceId)) {
-	hsize_t newSize[] = {requiredSize};
-	H5Sclose(spaceId);
-	H5Dset_extent(datasetId, newSize);
-	spaceId = H5Dget_space(datasetId);
+        hsize_t newSize[] = {requiredSize};
+        H5Sclose(spaceId);
+        H5Dset_extent(datasetId, newSize);
+        spaceId = H5Dget_space(datasetId);
       }
 
       for (const auto &E : extents) {
-	hsize_t start[] = {E.offset};
-	hsize_t block[] = {E.len};
+        hsize_t start[] = {E.offset};
+        hsize_t block[] = {E.len};
 
-	auto mspace = H5Screate_simple(1, block, NULL);
-	H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
-			    /*count=*/internal::one, block);
-	H5Dwrite(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
-	H5Sclose(mspace);
-	p += (block[0] * sz);
-	count += block[0];
+        auto mspace = H5Screate_simple(1, block, NULL);
+        H5Sselect_hyperslab(spaceId, H5S_SELECT_SET, start, /*stride=*/internal::one,
+                            /*count=*/internal::one, block);
+        H5Dwrite(datasetId, typeId, mspace, spaceId, H5P_DEFAULT, p);
+        H5Sclose(mspace);
+        p += (block[0] * sz);
+        count += block[0];
       }
       return count;
     }
@@ -98,13 +98,13 @@ namespace h5hep {
     /// elements in `dest` and `src` is given by `stride_dest` and `stride_src`, respectively.
     /// This function is mostly used to copy to/from column buffers.
     static inline void CopyElements(void *__restrict dest, const void *__restrict src, size_t n,
-				    size_t sz, size_t stride_dest, size_t stride_src) {
+                                    size_t sz, size_t stride_dest, size_t stride_src) {
       auto _dest = reinterpret_cast<unsigned char*>(dest);
       auto _src = reinterpret_cast<const unsigned char*>(src);
       for (size_t i = 0; i < n; ++i) {
-	memcpy(_dest, _src, sz);
-	_dest += stride_dest;
-	_src += stride_src;
+        memcpy(_dest, _src, sz);
+        _dest += stride_dest;
+        _src += stride_src;
       }
     }
   } // namespace internal
@@ -136,14 +136,14 @@ namespace h5hep {
     static std::shared_ptr<H5Location> Create(std::string_view path, unsigned flags = H5F_ACC_TRUNC) {
       auto fileId = H5Fcreate(path.data(), flags, H5P_DEFAULT, H5P_DEFAULT);
       if (fileId == H5I_INVALID_HID)
-	throw std::runtime_error("H5Fcreate error");
+        throw std::runtime_error("H5Fcreate error");
       return std::shared_ptr<H5Location>(new H5File(fileId));
     }
 
     static std::shared_ptr<H5Location> Open(std::string_view path, unsigned flags = H5F_ACC_RDONLY) {
       auto fileId = H5Fopen(path.data(), flags, H5P_DEFAULT);
       if (fileId == H5I_INVALID_HID)
-	throw std::runtime_error("H5Fopen error");
+        throw std::runtime_error("H5Fopen error");
       return std::shared_ptr<H5Location>(new H5File(fileId));
     }
   };
@@ -178,8 +178,8 @@ namespace h5hep {
 
     void RealizeSchema(void *privateData = nullptr) {
       for (size_t i = 0; i < root->children.size(); ++i) {
-	if (root->children[i]->kind == schema::NodeKind::COLLECTION)
-	  collectionIdxs.push_back(i);
+        if (root->children[i]->kind == schema::NodeKind::COLLECTION)
+          collectionIdxs.push_back(i);
       }
       root->Realize(*this, privateData);
     }
@@ -189,11 +189,11 @@ namespace h5hep {
     virtual void InitializeCollections(const std::vector<Span> &extents, void *buf) const {
       auto p = reinterpret_cast<unsigned char*>(buf);
       for_each_row_in_extentlist(extents, E, i) {
-	for (size_t j : collectionIdxs) {
-	  const auto &C = root->children[j];
-	  C->InitializeValue(p + C->offset);
-	}
-	p += root->size;
+        for (size_t j : collectionIdxs) {
+          const auto &C = root->children[j];
+          C->InitializeValue(p + C->offset);
+        }
+        p += root->size;
       }
     }
 
@@ -201,7 +201,7 @@ namespace h5hep {
     ReaderWriter(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot)
       : location(location), root(schemaRoot->Clone()) {}
     ReaderWriter(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot,
-		 const WriteProperties &props)
+                 const WriteProperties &props)
       : location(location), root(schemaRoot->Clone()), props(props) {}
     virtual ~ReaderWriter() {}
 

--- a/root/tree/tree/h5hep/h5hep/io.hxx
+++ b/root/tree/tree/h5hep/h5hep/io.hxx
@@ -252,6 +252,8 @@ namespace h5hep {
     BufferedWriter(std::shared_ptr<h5hep::ReaderWriter> writer)
       : writer(writer), capacity(writer->GetWriteProperties().GetChunkSize()), buffer(new T[capacity]) {}
     ~BufferedWriter() { if (count) Flush(); }
+    size_t GetCapacity() const { return capacity; }
+    size_t GetCount() const { return count; }
 
     void Write(const T& val) {
       buffer[count++] = val;

--- a/root/tree/tree/h5hep/h5hep/io.hxx
+++ b/root/tree/tree/h5hep/h5hep/io.hxx
@@ -257,6 +257,10 @@ namespace h5hep {
       buffer[count++] = val;
       if (count == capacity) Flush();
     }
+    void Write(T&& val) {
+      buffer[count++] = std::move(val);
+      if (count == capacity) Flush();
+    }
   };
 
 } // namespace h5hep

--- a/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
+++ b/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
@@ -1,0 +1,387 @@
+/// \file h5hep/model_columnarfnal.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-11-08
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+///
+/// A (restricted) column model that uses one HDF5 dataset per primitive column. It is compliant with
+/// https://inspirehep.net/files/e048b0cd122919dc9a009793983a81e0.
+
+#ifndef _H5HEP_MODEL_COLUMNARFNAL_HXX
+#define _H5HEP_MODEL_COLUMNARFNAL_HXX
+
+#include <h5hep/io.hxx>
+#include <h5hep/schema.hxx>
+
+#include <hdf5.h>
+
+#include <algorithm>
+#include <optional>
+
+namespace h5hep {
+
+  namespace schema {
+    template <>
+    class Node<ColumnModel::COLUMNAR_FNAL> : public NodeBase {
+    protected:
+      /// \brief The dataspace and dataset identifiers for this column
+      mutable hid_t spaceId = H5I_INVALID_HID;
+      hid_t datasetId = H5I_INVALID_HID;
+
+    public:
+      struct RealizePrivateData {
+	hid_t parentGroup; /// \brief Where to create/access the dataset for this column 
+	hid_t dcpl; /// \brief If the schema is being initialized, the dataset creation property list
+      };
+
+      using NodePtr_t = std::shared_ptr<Node<ColumnModel::COLUMNAR_FNAL>>;
+      using MemberList_t = std::vector<NodePtr_t>;
+
+      Node(NodeKind k, std::string_view name, size_t offset, size_t size, hid_t tid = H5I_INVALID_HID)
+	: NodeBase(k, name, offset, size, tid) {}
+      Node(const Node &) = default;
+      virtual ~Node() {
+	if (datasetId != H5I_INVALID_HID) H5Dclose(datasetId);
+	if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
+      }
+
+      hsize_t GetDataspaceSize() { return internal::GetDataspaceSize(spaceId); }
+    };
+
+    template <typename T>
+    class PrimitiveNode<ColumnModel::COLUMNAR_FNAL, T> : public Node<ColumnModel::COLUMNAR_FNAL> {
+    public:
+      using Value_t = T;
+
+      PrimitiveNode(std::string_view name, size_t offset)
+	: Node(NodeKind::PRIMITIVE, name, offset, sizeof(T), GetH5TypeId<T>()) {}
+      PrimitiveNode(const PrimitiveNode &) = default;
+
+      void Realize(ReaderWriter &rw, void *privateData) override {
+	const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
+
+	if (info.dcpl != H5I_INVALID_HID) {
+	  spaceId = H5Screate_simple(1, /*dims=*/internal::zero, /*maxdims=*/internal::unlimited);
+	  datasetId = H5Dcreate(info.parentGroup, name.c_str(), typeId, spaceId,
+			    H5P_DEFAULT, info.dcpl, H5P_DEFAULT);
+	} else {
+	  datasetId = H5Dopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
+	  spaceId = H5Dget_space(datasetId);
+	}
+      }
+
+      size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
+	return internal::SimpleReadExtents(extents, buf, datasetId, spaceId, typeId);
+      }
+
+      size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
+	return internal::SimpleWriteExtents(extents, buf, datasetId, spaceId, typeId);
+      }
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(*this);
+      }
+    };
+
+    template <typename T>
+    class StructNode<ColumnModel::COLUMNAR_FNAL, T> : public Node<ColumnModel::COLUMNAR_FNAL> {
+    public:
+      using Value_t = T;
+
+      StructNode(std::string_view name, size_t offset, const MemberList_t &v)
+	: Node(NodeKind::STRUCT, name, offset, sizeof(T))
+      {
+	for (auto &I : v)
+	  children.push_back(std::static_pointer_cast<NodeBase>(I));
+      }
+      StructNode(const StructNode &) = default;
+
+      size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
+	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+					   [](size_t a, const Span &b) { return a + b.len; });
+	size_t largestT = std::accumulate(children.begin(), children.end(), 0,
+					  [](size_t a, const auto b) { return std::max(a, b->size); });
+	size_t count = 0;
+
+	auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
+	for (const auto &I : children) {
+	  auto c = I->ReadExtents(extents, columnBuffer.get());
+	  // For collections, we unpack an array of `hvl_t[]` from `columnBuffer`
+	  internal::CopyElements(reinterpret_cast<unsigned char*>(buf) + I->offset,
+				 columnBuffer.get(),
+				 c, I->size, size, I->size);
+	  if (I->kind != NodeKind::COLLECTION) // FIXME:
+	    count = std::max(count, c);
+	}
+	return count;
+      }
+
+      size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
+	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+					   [](size_t a, const Span &b) { return a + b.len; });
+	size_t largestT = std::accumulate(children.begin(), children.end(), 0,
+					  [](size_t a, const auto b) { return std::max(a, b->size); });
+
+	auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
+	for (const auto &I : children) {
+	  // For collections, we pack an array of `hvl_t[]` into `columnBuffer`
+	  internal::CopyElements(columnBuffer.get(),
+				 reinterpret_cast<const unsigned char*>(buf) + I->offset,
+				 nElements, I->size, size, I->size);
+	  I->WriteExtents(extents, columnBuffer.get());
+	}
+	return nElements;
+      }
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	MemberList_t v;
+	for (auto &I : children)
+	  v.push_back(std::reinterpret_pointer_cast<NodePtr_t::element_type>(I->Clone()));
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, v);
+      }
+    };
+
+    template <typename T>
+    class CollectionNode<ColumnModel::COLUMNAR_FNAL, T> : public Node<ColumnModel::COLUMNAR_FNAL> {
+      template <typename U>
+      struct SequentialColumnReader {
+	PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &column;
+	size_t chunkSize;
+	std::unique_ptr<U[]> chunk;
+	size_t nEltsInChunk{};
+	size_t offset{};
+
+	SequentialColumnReader(PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &c, size_t chunkSize)
+	  : column(c), chunkSize(chunkSize) {}
+
+	void ReadNextChunk() {
+	  nEltsInChunk = column.ReadExtents(std::vector<Span>{{offset, chunkSize}}, chunk.get());
+	}
+
+	std::optional<U> operator*() {
+	  if (unlikely(!chunk.get())) {
+	    chunk = std::make_unique<U[]>(chunkSize);
+	    ReadNextChunk();
+	  }
+	  return nEltsInChunk == 0 ? std::optional<U>() : std::optional<U>(chunk[offset % chunkSize]);
+	}
+
+	SequentialColumnReader &operator++(int) {
+	  if ((++offset % chunkSize) == 0)
+	    ReadNextChunk();
+	  return *this;
+	}
+      };
+
+      using IndexColumnValue_t = unsigned long;
+      /// \brief A column used to identify elements in the collection
+      std::unique_ptr<PrimitiveNode<ColumnModel::COLUMNAR_FNAL, IndexColumnValue_t>> indexColumn;
+      /// \brief Sequential reader used in `LookupElements()`
+      SequentialColumnReader<IndexColumnValue_t> indexColumnReader{*indexColumn.get(),
+	/*chunkSize=*/(512 * 1024) / sizeof(IndexColumnValue_t)};
+
+      void ThrowIfNestedCollections(std::shared_ptr<NodeBase> inner) {
+	if (inner->kind == NodeKind::COLLECTION)
+	  throw std::runtime_error("This column model doesn't support nested collections");
+	for (auto &I : inner->children)
+	  ThrowIfNestedCollections(I);
+      }
+
+      /// \brief For each entry described in `in`, add to `out` the corresponding extent for elements in the
+      /// collection.
+      /// \return Total number of elements
+      ///
+      /// This naive implementation only allows sequential access to the collection. Also, although incompatible
+      /// with the original publication, collections are better encoded using an index column of type
+      /// `h5hep::H5Span` (or a VL type of it).
+      size_t LookupElements(const std::vector<Span> &in, std::vector<Span> &out) {
+	size_t count = 0;
+	for_each_row_in_extentlist(in, E, i) {
+	  const auto entryIdx = E.offset + i;
+	  Span extent{(size_t)-1, 0};
+
+	  while (auto idx = *indexColumnReader) {
+	    if (extent.offset == (size_t)-1 && idx == entryIdx)
+	      extent.offset = indexColumnReader.offset;
+	    if (idx > entryIdx)
+	      break;
+	    indexColumnReader++;
+	  }
+	  if (extent.offset != (size_t)-1)
+	    extent.len = (indexColumnReader.offset - extent.offset);
+
+	  out.push_back(extent);
+	  count += extent.len;
+	}
+	return count;
+      }
+
+    public:
+      using Value_t = T;
+
+      CollectionNode(std::string_view name, size_t offset, NodePtr_t inner)
+	: Node(NodeKind::COLLECTION, name, offset, sizeof(hvl_t))
+      {
+	ThrowIfNestedCollections(std::static_pointer_cast<NodeBase>(inner));
+
+	children = {std::static_pointer_cast<NodeBase>(inner)};
+	indexColumn = std::make_unique<typename decltype(indexColumn)::element_type>("Event ID", 0);
+      }
+      CollectionNode(const CollectionNode &) = default;
+
+      void Realize(ReaderWriter &rw, void *privateData) override {
+	const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
+
+	hid_t group = (info.dcpl != H5I_INVALID_HID)
+	  ? H5Gcreate(info.parentGroup, name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
+	  : H5Gopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
+
+	RealizePrivateData newInfo{group, info.dcpl};
+	indexColumn->Realize(rw, &newInfo);
+	NodeBase::Realize(rw, &newInfo);
+      }
+
+      void InitializeValue(void *p) override {
+	reinterpret_cast<CollectionBase*>(p)->assign({},
+		   [](void *p, void *data) { delete[] reinterpret_cast<T*>(p); });
+      }
+
+      size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
+	auto hvls = reinterpret_cast<hvl_t*>(buf);
+	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+					   [](size_t a, const Span &b) { return a + b.len; });
+	std::vector<Span> eltExts;
+	LookupElements(extents, eltExts);
+
+	size_t hvl_i = 0;
+	for (const auto &E : eltExts) {
+	  auto &hvl = hvls[hvl_i++];
+
+	  if (E.offset == (size_t)-1) {
+	    hvl = {};
+	    continue;
+	  }
+
+	  hvl.len = E.len;
+	  hvl.p = new T[E.len];
+	  children.back()->ReadExtents(std::vector<Span>{{E.offset, E.len}}, hvl.p);
+	}
+	return nElements;
+      }
+
+      size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
+	auto hvls = reinterpret_cast<const hvl_t*>(buf);
+	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+					   [](size_t a, const Span &b) { return a + b.len; });
+	size_t szLargestCollection = std::accumulate(hvls, hvls + nElements, 0,
+						     [](size_t a, const hvl_t &b) { return std::max(a, b.len); });
+	auto bufIdxColumn = std::make_unique<IndexColumnValue_t[]>(szLargestCollection);
+
+	hsize_t offset = indexColumn->GetDataspaceSize();
+	size_t hvl_i = 0;
+	for_each_row_in_extentlist(extents, E, i) {
+	  auto &hvl = hvls[hvl_i++];
+	  const auto rowIdx = E.offset + i;
+
+	  // Write a stride of `rowIdx` values in the index column
+	  std::fill(bufIdxColumn.get(), bufIdxColumn.get() + hvl.len, rowIdx);
+	  indexColumn->WriteExtents(std::vector<Span>{{offset, hvl.len}}, bufIdxColumn.get());
+
+	  children.back()->WriteExtents(std::vector<Span>{{offset, hvl.len}}, hvl.p);
+	  offset += hvl.len;
+	}
+	return nElements;
+      }
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	auto inner = std::reinterpret_pointer_cast<NodePtr_t::element_type>(children.back()->Clone());
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, inner);
+      }
+    };
+  } //namespace schema
+
+  template <>
+  class ReaderWriterSpec<ColumnModel::COLUMNAR_FNAL> : public ReaderWriter {
+    using Node_t = schema::Node<ColumnModel::COLUMNAR_FNAL>;
+
+    struct Metadata_t {
+      static constexpr const char *attrName = "$Metadata";
+      unsigned long attrs[2]{};
+      hid_t spaceId;
+      hid_t attrId;
+
+      Metadata_t(hid_t location) {
+	attrId = H5Aopen(location, attrName, H5P_DEFAULT);
+	spaceId = H5Aget_space(attrId);
+	H5Aread(attrId, H5T_NATIVE_LONG, attrs);
+      }
+      Metadata_t(hid_t location, const WriteProperties &props)
+	: attrs{props.GetChunkSize(), 0U}
+      {
+	hsize_t sz = std::extent<decltype(attrs)>::value;
+	spaceId = H5Screate_simple(1, &sz, NULL);
+	attrId = H5Acreate(location, attrName, H5T_NATIVE_ULONG, spaceId, H5P_DEFAULT, H5P_DEFAULT);
+	H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
+      }
+      ~Metadata_t() {
+	if (attrId != H5I_INVALID_HID) H5Aclose(attrId);
+	if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
+      }
+
+      // TODO: should the compression level be also stored in `attrs`?
+      WriteProperties GetWriteProperties() const { return WriteProperties{attrs[0], 0U}; }
+
+      size_t GetNEntries() const { return attrs[1]; }
+      void SetNEntries(size_t n) {
+	attrs[1] = n;
+	H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
+      }
+    } metadata;
+
+  public:
+    ReaderWriterSpec(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot)
+      : ReaderWriter(location, schemaRoot), metadata(location->GetHandle())
+    {
+      props = metadata.GetWriteProperties();
+      Node_t::RealizePrivateData info{/*parentGroup=*/location->GetHandle(), /*dcpl=*/H5I_INVALID_HID};
+      RealizeSchema(&info);
+    }
+
+    ReaderWriterSpec(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot,
+		 const WriteProperties &props)
+      : ReaderWriter(location, schemaRoot, props), metadata(location->GetHandle(), props)
+    {
+      hsize_t chunkSize[] = {props.GetChunkSize()};
+      dcpl = H5Pcreate(H5P_DATASET_CREATE);
+      if (auto level = props.GetCompressionLevel())
+	H5Pset_deflate(dcpl, level);
+      H5Pset_chunk(dcpl, 1, chunkSize);
+
+      Node_t::RealizePrivateData info{/*parentGroup=*/location->GetHandle(), /*dcpl=*/dcpl};
+      RealizeSchema(&info);
+    }
+
+    virtual ~ReaderWriterSpec() {
+      if (dcpl != H5I_INVALID_HID) H5Pclose(dcpl);
+    }
+
+    size_t GetNEntries() const override { return metadata.GetNEntries(); }
+
+    size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
+      // TODO: non-sequential access should throw (see `LookupElements()` restrictions)
+      InitializeCollections(extents, buf);
+      return root->ReadExtents(extents, buf);
+    }
+
+    size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
+      auto size = internal::GetMinimumDatasetSize(extents);
+      if (size > GetNEntries()) // FIXME:
+	metadata.SetNEntries(size);
+      return root->WriteExtents(extents, buf);
+    }
+  };
+
+} // namespace h5hep
+
+#endif // _H5HEP_MODEL_COLUMNARFNAL_HXX

--- a/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
+++ b/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
@@ -128,7 +128,7 @@ namespace h5hep {
 	  // For collections, we pack an array of `hvl_t[]` into `columnBuffer`
 	  internal::CopyElements(columnBuffer.get(),
 				 reinterpret_cast<const unsigned char*>(buf) + I->offset,
-				 nElements, I->size, size, I->size);
+				 nElements, I->size, I->size, size);
 	  I->WriteExtents(extents, columnBuffer.get());
 	}
 	return nElements;

--- a/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
+++ b/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
@@ -168,7 +168,8 @@ namespace h5hep {
 	}
 
 	SequentialColumnReader &operator++(int) {
-	  if ((++offset % chunkSize) == 0)
+	  auto offsetInChunk = ++offset % chunkSize;
+	  if (offsetInChunk == 0 || offsetInChunk == nEltsInChunk)
 	    ReadNextChunk();
 	  return *this;
 	}

--- a/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
+++ b/root/tree/tree/h5hep/h5hep/model_columnarfnal.hxx
@@ -31,19 +31,19 @@ namespace h5hep {
 
     public:
       struct RealizePrivateData {
-	hid_t parentGroup; /// \brief Where to create/access the dataset for this column 
-	hid_t dcpl; /// \brief If the schema is being initialized, the dataset creation property list
+        hid_t parentGroup; /// \brief Where to create/access the dataset for this column 
+        hid_t dcpl; /// \brief If the schema is being initialized, the dataset creation property list
       };
 
       using NodePtr_t = std::shared_ptr<Node<ColumnModel::COLUMNAR_FNAL>>;
       using MemberList_t = std::vector<NodePtr_t>;
 
       Node(NodeKind k, std::string_view name, size_t offset, size_t size, hid_t tid = H5I_INVALID_HID)
-	: NodeBase(k, name, offset, size, tid) {}
+        : NodeBase(k, name, offset, size, tid) {}
       Node(const Node &) = default;
       virtual ~Node() {
-	if (datasetId != H5I_INVALID_HID) H5Dclose(datasetId);
-	if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
+        if (datasetId != H5I_INVALID_HID) H5Dclose(datasetId);
+        if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
       }
 
       hsize_t GetDataspaceSize() { return internal::GetDataspaceSize(spaceId); }
@@ -55,32 +55,32 @@ namespace h5hep {
       using Value_t = T;
 
       PrimitiveNode(std::string_view name, size_t offset)
-	: Node(NodeKind::PRIMITIVE, name, offset, sizeof(T), GetH5TypeId<T>()) {}
+        : Node(NodeKind::PRIMITIVE, name, offset, sizeof(T), GetH5TypeId<T>()) {}
       PrimitiveNode(const PrimitiveNode &) = default;
 
       void Realize(ReaderWriter &rw, void *privateData) override {
-	const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
+        const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
 
-	if (info.dcpl != H5I_INVALID_HID) {
-	  spaceId = H5Screate_simple(1, /*dims=*/internal::zero, /*maxdims=*/internal::unlimited);
-	  datasetId = H5Dcreate(info.parentGroup, name.c_str(), typeId, spaceId,
-			    H5P_DEFAULT, info.dcpl, H5P_DEFAULT);
-	} else {
-	  datasetId = H5Dopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
-	  spaceId = H5Dget_space(datasetId);
-	}
+        if (info.dcpl != H5I_INVALID_HID) {
+          spaceId = H5Screate_simple(1, /*dims=*/internal::zero, /*maxdims=*/internal::unlimited);
+          datasetId = H5Dcreate(info.parentGroup, name.c_str(), typeId, spaceId,
+                            H5P_DEFAULT, info.dcpl, H5P_DEFAULT);
+        } else {
+          datasetId = H5Dopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
+          spaceId = H5Dget_space(datasetId);
+        }
       }
 
       size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
-	return internal::SimpleReadExtents(extents, buf, datasetId, spaceId, typeId);
+        return internal::SimpleReadExtents(extents, buf, datasetId, spaceId, typeId);
       }
 
       size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
-	return internal::SimpleWriteExtents(extents, buf, datasetId, spaceId, typeId);
+        return internal::SimpleWriteExtents(extents, buf, datasetId, spaceId, typeId);
       }
 
       std::shared_ptr<NodeBase> Clone() const override {
-	return std::make_shared<typename std::decay<decltype(*this)>::type>(*this);
+        return std::make_shared<typename std::decay<decltype(*this)>::type>(*this);
       }
     };
 
@@ -90,55 +90,55 @@ namespace h5hep {
       using Value_t = T;
 
       StructNode(std::string_view name, size_t offset, const MemberList_t &v)
-	: Node(NodeKind::STRUCT, name, offset, sizeof(T))
+        : Node(NodeKind::STRUCT, name, offset, sizeof(T))
       {
-	for (auto &I : v)
-	  children.push_back(std::static_pointer_cast<NodeBase>(I));
+        for (auto &I : v)
+          children.push_back(std::static_pointer_cast<NodeBase>(I));
       }
       StructNode(const StructNode &) = default;
 
       size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
-	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
-					   [](size_t a, const Span &b) { return a + b.len; });
-	size_t largestT = std::accumulate(children.begin(), children.end(), 0,
-					  [](size_t a, const auto b) { return std::max(a, b->size); });
-	size_t count = 0;
+        size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+                                           [](size_t a, const Span &b) { return a + b.len; });
+        size_t largestT = std::accumulate(children.begin(), children.end(), 0,
+                                          [](size_t a, const auto b) { return std::max(a, b->size); });
+        size_t count = 0;
 
-	auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
-	for (const auto &I : children) {
-	  auto c = I->ReadExtents(extents, columnBuffer.get());
-	  // For collections, we unpack an array of `hvl_t[]` from `columnBuffer`
-	  internal::CopyElements(reinterpret_cast<unsigned char*>(buf) + I->offset,
-				 columnBuffer.get(),
-				 c, I->size, size, I->size);
-	  if (I->kind != NodeKind::COLLECTION) // FIXME:
-	    count = std::max(count, c);
-	}
-	return count;
+        auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
+        for (const auto &I : children) {
+          auto c = I->ReadExtents(extents, columnBuffer.get());
+          // For collections, we unpack an array of `hvl_t[]` from `columnBuffer`
+          internal::CopyElements(reinterpret_cast<unsigned char*>(buf) + I->offset,
+                                 columnBuffer.get(),
+                                 c, I->size, size, I->size);
+          if (I->kind != NodeKind::COLLECTION) // FIXME:
+            count = std::max(count, c);
+        }
+        return count;
       }
 
       size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
-	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
-					   [](size_t a, const Span &b) { return a + b.len; });
-	size_t largestT = std::accumulate(children.begin(), children.end(), 0,
-					  [](size_t a, const auto b) { return std::max(a, b->size); });
+        size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+                                           [](size_t a, const Span &b) { return a + b.len; });
+        size_t largestT = std::accumulate(children.begin(), children.end(), 0,
+                                          [](size_t a, const auto b) { return std::max(a, b->size); });
 
-	auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
-	for (const auto &I : children) {
-	  // For collections, we pack an array of `hvl_t[]` into `columnBuffer`
-	  internal::CopyElements(columnBuffer.get(),
-				 reinterpret_cast<const unsigned char*>(buf) + I->offset,
-				 nElements, I->size, I->size, size);
-	  I->WriteExtents(extents, columnBuffer.get());
-	}
-	return nElements;
+        auto columnBuffer = std::make_unique<unsigned char[]>(nElements * largestT);
+        for (const auto &I : children) {
+          // For collections, we pack an array of `hvl_t[]` into `columnBuffer`
+          internal::CopyElements(columnBuffer.get(),
+                                 reinterpret_cast<const unsigned char*>(buf) + I->offset,
+                                 nElements, I->size, I->size, size);
+          I->WriteExtents(extents, columnBuffer.get());
+        }
+        return nElements;
       }
 
       std::shared_ptr<NodeBase> Clone() const override {
-	MemberList_t v;
-	for (auto &I : children)
-	  v.push_back(std::reinterpret_pointer_cast<NodePtr_t::element_type>(I->Clone()));
-	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, v);
+        MemberList_t v;
+        for (auto &I : children)
+          v.push_back(std::reinterpret_pointer_cast<NodePtr_t::element_type>(I->Clone()));
+        return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, v);
       }
     };
 
@@ -146,33 +146,33 @@ namespace h5hep {
     class CollectionNode<ColumnModel::COLUMNAR_FNAL, T> : public Node<ColumnModel::COLUMNAR_FNAL> {
       template <typename U>
       struct SequentialColumnReader {
-	PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &column;
-	size_t chunkSize;
-	std::unique_ptr<U[]> chunk;
-	size_t nEltsInChunk{};
-	size_t offset{};
+        PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &column;
+        size_t chunkSize;
+        std::unique_ptr<U[]> chunk;
+        size_t nEltsInChunk{};
+        size_t offset{};
 
-	SequentialColumnReader(PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &c, size_t chunkSize)
-	  : column(c), chunkSize(chunkSize) {}
+        SequentialColumnReader(PrimitiveNode<ColumnModel::COLUMNAR_FNAL, U> &c, size_t chunkSize)
+          : column(c), chunkSize(chunkSize) {}
 
-	void ReadNextChunk() {
-	  nEltsInChunk = column.ReadExtents(std::vector<Span>{{offset, chunkSize}}, chunk.get());
-	}
+        void ReadNextChunk() {
+          nEltsInChunk = column.ReadExtents(std::vector<Span>{{offset, chunkSize}}, chunk.get());
+        }
 
-	std::optional<U> operator*() {
-	  if (unlikely(!chunk.get())) {
-	    chunk = std::make_unique<U[]>(chunkSize);
-	    ReadNextChunk();
-	  }
-	  return nEltsInChunk == 0 ? std::optional<U>() : std::optional<U>(chunk[offset % chunkSize]);
-	}
+        std::optional<U> operator*() {
+          if (unlikely(!chunk.get())) {
+            chunk = std::make_unique<U[]>(chunkSize);
+            ReadNextChunk();
+          }
+          return nEltsInChunk == 0 ? std::optional<U>() : std::optional<U>(chunk[offset % chunkSize]);
+        }
 
-	SequentialColumnReader &operator++(int) {
-	  auto offsetInChunk = ++offset % chunkSize;
-	  if (offsetInChunk == 0 || offsetInChunk == nEltsInChunk)
-	    ReadNextChunk();
-	  return *this;
-	}
+        SequentialColumnReader &operator++(int) {
+          auto offsetInChunk = ++offset % chunkSize;
+          if (offsetInChunk == 0 || offsetInChunk == nEltsInChunk)
+            ReadNextChunk();
+          return *this;
+        }
       };
 
       using IndexColumnValue_t = unsigned long;
@@ -183,10 +183,10 @@ namespace h5hep {
       static constexpr size_t defaultChunkSize = (512 * 1024) / sizeof(IndexColumnValue_t);
 
       void ThrowIfNestedCollections(std::shared_ptr<NodeBase> inner) {
-	if (inner->kind == NodeKind::COLLECTION)
-	  throw std::runtime_error("This column model doesn't support nested collections");
-	for (auto &I : inner->children)
-	  ThrowIfNestedCollections(I);
+        if (inner->kind == NodeKind::COLLECTION)
+          throw std::runtime_error("This column model doesn't support nested collections");
+        for (auto &I : inner->children)
+          ThrowIfNestedCollections(I);
       }
 
       /// \brief For each entry described in `in`, add to `out` the corresponding extent for elements in the
@@ -197,109 +197,109 @@ namespace h5hep {
       /// with the original publication, collections are better encoded using an index column of type
       /// `h5hep::H5Span` (or a VL type of it).
       size_t LookupElements(const std::vector<Span> &in, std::vector<Span> &out) {
-	size_t count = 0;
-	for_each_row_in_extentlist(in, E, i) {
-	  const auto entryIdx = E.offset + i;
-	  Span extent{(size_t)-1, 0};
+        size_t count = 0;
+        for_each_row_in_extentlist(in, E, i) {
+          const auto entryIdx = E.offset + i;
+          Span extent{(size_t)-1, 0};
 
-	  while (auto idx = *(*indexColumnReader)) {
-	    if (extent.offset == (size_t)-1 && idx == entryIdx)
-	      extent.offset = indexColumnReader->offset;
-	    if (idx > entryIdx)
-	      break;
-	    (*indexColumnReader)++;
-	  }
-	  if (extent.offset != (size_t)-1)
-	    extent.len = (indexColumnReader->offset - extent.offset);
+          while (auto idx = *(*indexColumnReader)) {
+            if (extent.offset == (size_t)-1 && idx == entryIdx)
+              extent.offset = indexColumnReader->offset;
+            if (idx > entryIdx)
+              break;
+            (*indexColumnReader)++;
+          }
+          if (extent.offset != (size_t)-1)
+            extent.len = (indexColumnReader->offset - extent.offset);
 
-	  out.push_back(extent);
-	  count += extent.len;
-	}
-	return count;
+          out.push_back(extent);
+          count += extent.len;
+        }
+        return count;
       }
 
     public:
       using Value_t = T;
 
       CollectionNode(std::string_view name, size_t offset, NodePtr_t inner)
-	: Node(NodeKind::COLLECTION, name, offset, sizeof(hvl_t))
+        : Node(NodeKind::COLLECTION, name, offset, sizeof(hvl_t))
       {
-	ThrowIfNestedCollections(std::static_pointer_cast<NodeBase>(inner));
+        ThrowIfNestedCollections(std::static_pointer_cast<NodeBase>(inner));
 
-	children = {std::static_pointer_cast<NodeBase>(inner)};
-	indexColumn = std::make_unique<typename decltype(indexColumn)::element_type>("Event ID", 0);
-	indexColumnReader = std::make_unique<SequentialColumnReader<IndexColumnValue_t>>
-	  (*indexColumn.get(), defaultChunkSize);
+        children = {std::static_pointer_cast<NodeBase>(inner)};
+        indexColumn = std::make_unique<typename decltype(indexColumn)::element_type>("Event ID", 0);
+        indexColumnReader = std::make_unique<SequentialColumnReader<IndexColumnValue_t>>
+          (*indexColumn.get(), defaultChunkSize);
       }
       CollectionNode(const CollectionNode &) = default;
 
       void Realize(ReaderWriter &rw, void *privateData) override {
-	const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
+        const auto &info = *reinterpret_cast<RealizePrivateData*>(privateData);
 
-	hid_t group = (info.dcpl != H5I_INVALID_HID)
-	  ? H5Gcreate(info.parentGroup, name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
-	  : H5Gopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
+        hid_t group = (info.dcpl != H5I_INVALID_HID)
+          ? H5Gcreate(info.parentGroup, name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
+          : H5Gopen(info.parentGroup, name.c_str(), H5P_DEFAULT);
 
-	RealizePrivateData newInfo{group, info.dcpl};
-	indexColumn->Realize(rw, &newInfo);
-	NodeBase::Realize(rw, &newInfo);
+        RealizePrivateData newInfo{group, info.dcpl};
+        indexColumn->Realize(rw, &newInfo);
+        NodeBase::Realize(rw, &newInfo);
       }
 
       void InitializeValue(void *p) override {
-	reinterpret_cast<CollectionBase*>(p)->assign({},
-		   [](void *p, void *data) { delete[] reinterpret_cast<T*>(p); });
+        reinterpret_cast<CollectionBase*>(p)->assign({},
+                   [](void *p, void *data) { delete[] reinterpret_cast<T*>(p); });
       }
 
       size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
-	auto hvls = reinterpret_cast<hvl_t*>(buf);
-	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
-					   [](size_t a, const Span &b) { return a + b.len; });
-	std::vector<Span> eltExts;
-	LookupElements(extents, eltExts);
+        auto hvls = reinterpret_cast<hvl_t*>(buf);
+        size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+                                           [](size_t a, const Span &b) { return a + b.len; });
+        std::vector<Span> eltExts;
+        LookupElements(extents, eltExts);
 
-	size_t hvl_i = 0;
-	for (const auto &E : eltExts) {
-	  auto &hvl = hvls[hvl_i++];
+        size_t hvl_i = 0;
+        for (const auto &E : eltExts) {
+          auto &hvl = hvls[hvl_i++];
 
-	  if (E.offset == (size_t)-1) {
-	    hvl = {};
-	    continue;
-	  }
+          if (E.offset == (size_t)-1) {
+            hvl = {};
+            continue;
+          }
 
-	  hvl.len = E.len;
-	  hvl.p = new T[E.len];
-	  children.back()->ReadExtents(std::vector<Span>{{E.offset, E.len}}, hvl.p);
-	}
-	return nElements;
+          hvl.len = E.len;
+          hvl.p = new T[E.len];
+          children.back()->ReadExtents(std::vector<Span>{{E.offset, E.len}}, hvl.p);
+        }
+        return nElements;
       }
 
       size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
-	auto hvls = reinterpret_cast<const hvl_t*>(buf);
-	size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
-					   [](size_t a, const Span &b) { return a + b.len; });
-	size_t szLargestCollection = std::accumulate(hvls, hvls + nElements, 0,
-						     [](size_t a, const hvl_t &b) { return std::max(a, b.len); });
-	auto bufIdxColumn = std::make_unique<IndexColumnValue_t[]>(szLargestCollection);
+        auto hvls = reinterpret_cast<const hvl_t*>(buf);
+        size_t nElements = std::accumulate(extents.begin(), extents.end(), 0,
+                                           [](size_t a, const Span &b) { return a + b.len; });
+        size_t szLargestCollection = std::accumulate(hvls, hvls + nElements, 0,
+                                                     [](size_t a, const hvl_t &b) { return std::max(a, b.len); });
+        auto bufIdxColumn = std::make_unique<IndexColumnValue_t[]>(szLargestCollection);
 
-	hsize_t offset = indexColumn->GetDataspaceSize();
-	size_t hvl_i = 0;
-	for_each_row_in_extentlist(extents, E, i) {
-	  auto &hvl = hvls[hvl_i++];
-	  const auto rowIdx = E.offset + i;
+        hsize_t offset = indexColumn->GetDataspaceSize();
+        size_t hvl_i = 0;
+        for_each_row_in_extentlist(extents, E, i) {
+          auto &hvl = hvls[hvl_i++];
+          const auto rowIdx = E.offset + i;
 
-	  // Write a stride of `rowIdx` values in the index column
-	  std::fill(bufIdxColumn.get(), bufIdxColumn.get() + hvl.len, rowIdx);
-	  indexColumn->WriteExtents(std::vector<Span>{{offset, hvl.len}}, bufIdxColumn.get());
+          // Write a stride of `rowIdx` values in the index column
+          std::fill(bufIdxColumn.get(), bufIdxColumn.get() + hvl.len, rowIdx);
+          indexColumn->WriteExtents(std::vector<Span>{{offset, hvl.len}}, bufIdxColumn.get());
 
-	  children.back()->WriteExtents(std::vector<Span>{{offset, hvl.len}}, hvl.p);
-	  offset += hvl.len;
-	}
-	return nElements;
+          children.back()->WriteExtents(std::vector<Span>{{offset, hvl.len}}, hvl.p);
+          offset += hvl.len;
+        }
+        return nElements;
       }
 
       std::shared_ptr<NodeBase> Clone() const override {
-	auto inner = std::reinterpret_pointer_cast<NodePtr_t::element_type>(children.back()->Clone());
-	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, inner);
+        auto inner = std::reinterpret_pointer_cast<NodePtr_t::element_type>(children.back()->Clone());
+        return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, inner);
       }
     };
   } //namespace schema
@@ -315,21 +315,21 @@ namespace h5hep {
       hid_t attrId;
 
       Metadata_t(hid_t location) {
-	attrId = H5Aopen(location, attrName, H5P_DEFAULT);
-	spaceId = H5Aget_space(attrId);
-	H5Aread(attrId, H5T_NATIVE_LONG, attrs);
+        attrId = H5Aopen(location, attrName, H5P_DEFAULT);
+        spaceId = H5Aget_space(attrId);
+        H5Aread(attrId, H5T_NATIVE_LONG, attrs);
       }
       Metadata_t(hid_t location, const WriteProperties &props)
-	: attrs{props.GetChunkSize(), 0U}
+        : attrs{props.GetChunkSize(), 0U}
       {
-	hsize_t sz = std::extent<decltype(attrs)>::value;
-	spaceId = H5Screate_simple(1, &sz, NULL);
-	attrId = H5Acreate(location, attrName, H5T_NATIVE_ULONG, spaceId, H5P_DEFAULT, H5P_DEFAULT);
-	H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
+        hsize_t sz = std::extent<decltype(attrs)>::value;
+        spaceId = H5Screate_simple(1, &sz, NULL);
+        attrId = H5Acreate(location, attrName, H5T_NATIVE_ULONG, spaceId, H5P_DEFAULT, H5P_DEFAULT);
+        H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
       }
       ~Metadata_t() {
-	if (attrId != H5I_INVALID_HID) H5Aclose(attrId);
-	if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
+        if (attrId != H5I_INVALID_HID) H5Aclose(attrId);
+        if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
       }
 
       // TODO: should the compression level be also stored in `attrs`?
@@ -337,8 +337,8 @@ namespace h5hep {
 
       size_t GetNEntries() const { return attrs[1]; }
       void SetNEntries(size_t n) {
-	attrs[1] = n;
-	H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
+        attrs[1] = n;
+        H5Awrite(attrId, H5T_NATIVE_ULONG, attrs);
       }
     } metadata;
 
@@ -352,13 +352,13 @@ namespace h5hep {
     }
 
     ReaderWriterSpec(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot,
-		 const WriteProperties &props)
+                 const WriteProperties &props)
       : ReaderWriter(location, schemaRoot, props), metadata(location->GetHandle(), props)
     {
       hsize_t chunkSize[] = {props.GetChunkSize()};
       dcpl = H5Pcreate(H5P_DATASET_CREATE);
       if (auto level = props.GetCompressionLevel())
-	H5Pset_deflate(dcpl, level);
+        H5Pset_deflate(dcpl, level);
       H5Pset_chunk(dcpl, 1, chunkSize);
 
       Node_t::RealizePrivateData info{/*parentGroup=*/location->GetHandle(), /*dcpl=*/dcpl};
@@ -380,7 +380,7 @@ namespace h5hep {
     size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
       auto size = internal::GetMinimumDatasetSize(extents);
       if (size > GetNEntries()) // FIXME:
-	metadata.SetNEntries(size);
+        metadata.SetNEntries(size);
       return root->WriteExtents(extents, buf);
     }
   };

--- a/root/tree/tree/h5hep/h5hep/model_compoundtype.hxx
+++ b/root/tree/tree/h5hep/h5hep/model_compoundtype.hxx
@@ -1,0 +1,170 @@
+/// \file h5hep/model_compoundtype.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-11-05
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+///
+/// Implements a column model that uses compound types; collections are encoded unsing HDF5 VL types.
+
+#ifndef _H5HEP_MODEL_COMPOUNDTYPE_HXX
+#define _H5HEP_MODEL_COMPOUNDTYPE_HXX
+
+#include <h5hep/io.hxx>
+#include <h5hep/schema.hxx>
+
+#include <hdf5.h>
+
+namespace h5hep {
+
+  namespace schema {
+    template <>
+    class Node<ColumnModel::COMPOUND_TYPE> : public NodeBase {
+    public:
+      using NodePtr_t = std::shared_ptr<Node<ColumnModel::COMPOUND_TYPE>>;
+      using MemberList_t = std::vector<NodePtr_t>;
+
+      Node(NodeKind k, std::string_view name, size_t offset, size_t size, hid_t tid = H5I_INVALID_HID)
+	: NodeBase(k, name, offset, size, tid) {}
+      Node(const Node &) = default;
+
+      size_t ReadExtents(const std::vector<Span> &extents, void *buf) override { return 0; }
+      size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override { return 0; }
+    };
+
+    template <typename T>
+    class PrimitiveNode<ColumnModel::COMPOUND_TYPE, T> : public Node<ColumnModel::COMPOUND_TYPE> {
+    public:
+      using Value_t = T;
+
+      PrimitiveNode(std::string_view name, size_t offset)
+	: Node(NodeKind::PRIMITIVE, name, offset, sizeof(T), GetH5TypeId<T>()) {}
+      PrimitiveNode(const PrimitiveNode &) = default;
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(*this);
+      }
+    };
+
+    template <typename T>
+    class StructNode<ColumnModel::COMPOUND_TYPE, T> : public Node<ColumnModel::COMPOUND_TYPE> {
+    public:
+      using Value_t = T;
+
+      StructNode(std::string_view name, size_t offset, const MemberList_t &v)
+	: Node(NodeKind::STRUCT, name, offset, sizeof(T))
+      {
+	for (auto &I : v)
+	  children.push_back(std::static_pointer_cast<NodeBase>(I));
+      }
+      StructNode(const StructNode &) = default;
+      virtual ~StructNode() { if (typeId != H5I_INVALID_HID) H5Tclose(typeId); }
+
+      void Realize(ReaderWriter &rw, void *privateData) override {
+	NodeBase::Realize(rw, privateData);
+	typeId = H5Tcreate(H5T_COMPOUND, size);
+	for (auto &I : children)
+	  H5Tinsert(typeId, I->name.c_str(), I->offset, I->typeId);
+      }
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	MemberList_t v;
+	for (auto &I : children)
+	  v.push_back(std::reinterpret_pointer_cast<NodePtr_t::element_type>(I->Clone()));
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, v);
+      }
+    };
+
+    template <typename T>
+    class CollectionNode<ColumnModel::COMPOUND_TYPE, T> : public Node<ColumnModel::COMPOUND_TYPE> {
+    public:
+      using Value_t = T;
+
+      CollectionNode(std::string_view name, size_t offset, NodePtr_t inner)
+	: Node(NodeKind::COLLECTION, name, offset, sizeof(hvl_t))
+      {
+	children = {std::static_pointer_cast<NodeBase>(inner)};
+      }
+      CollectionNode(const CollectionNode &) = default;
+      virtual ~CollectionNode() { if (typeId != H5I_INVALID_HID) H5Tclose(typeId); }
+
+      void Realize(ReaderWriter &rw, void *privateData) override {
+	NodeBase::Realize(rw, privateData);
+	typeId = H5Tvlen_create(children.back()->typeId);
+      }
+
+      void InitializeValue(void *p) override {
+	reinterpret_cast<CollectionBase*>(p)->assign({},
+		   [](void *p, void *data) {
+		     const auto that = reinterpret_cast<const CollectionNode<ColumnModel::COMPOUND_TYPE, T>*>(data);
+		     H5Dvlen_reclaim(that->children.back()->typeId,
+				     that->readerWriter->GetSpaceId(), H5P_DEFAULT, p);
+		   }, this);
+      }
+
+      std::shared_ptr<NodeBase> Clone() const override {
+	auto inner = std::reinterpret_pointer_cast<NodePtr_t::element_type>(children.back()->Clone());
+	return std::make_shared<typename std::decay<decltype(*this)>::type>(name, offset, inner);
+      }
+    };
+  } //namespace schema
+
+  template <>
+  class ReaderWriterSpec<ColumnModel::COMPOUND_TYPE> : public ReaderWriter {
+  public:
+    ReaderWriterSpec(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot)
+      : ReaderWriter(location, schemaRoot)
+    {
+      RealizeSchema();
+
+      datasetId = H5Dopen(location->GetHandle(), root->name.c_str(), H5P_DEFAULT);
+      spaceId = H5Dget_space(datasetId);
+      dcpl = H5Dget_create_plist(datasetId);
+
+      hsize_t chunkSize{};
+      H5Pget_chunk(dcpl, 1, &chunkSize);
+      props.SetChunkSize(chunkSize);
+      // TODO: retrieve deflate level, if using compression
+    }
+
+    ReaderWriterSpec(std::shared_ptr<H5Location> location, std::shared_ptr<schema::NodeBase> schemaRoot,
+		 const WriteProperties &props)
+      : ReaderWriter(location, schemaRoot, props)
+    {
+      hsize_t chunkSize[] = {props.GetChunkSize()};
+
+      dcpl = H5Pcreate(H5P_DATASET_CREATE);
+      if (auto level = props.GetCompressionLevel())
+	H5Pset_deflate(dcpl, level);
+      H5Pset_chunk(dcpl, 1, chunkSize);
+
+      RealizeSchema();
+
+      spaceId = H5Screate_simple(1, /*dims=*/internal::zero, /*maxdims=*/internal::unlimited);
+      datasetId = H5Dcreate(location->GetHandle(), root->name.c_str(), root->typeId, spaceId,
+			    H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    }
+
+    virtual ~ReaderWriterSpec() {
+      if (datasetId != H5I_INVALID_HID) H5Dclose(datasetId);
+      if (spaceId != H5I_INVALID_HID) H5Sclose(spaceId);
+      if (dcpl != H5I_INVALID_HID) H5Pclose(dcpl);
+    }
+
+    size_t GetNEntries() const override {
+      return internal::GetDataspaceSize(spaceId);
+    }
+
+    size_t ReadExtents(const std::vector<Span> &extents, void *buf) override {
+      InitializeCollections(extents, buf);
+      return internal::SimpleReadExtents(extents, buf, datasetId, spaceId, root->typeId);
+    }
+
+    size_t WriteExtents(const std::vector<Span> &extents, const void *buf) override {
+      return internal::SimpleWriteExtents(extents, buf, datasetId, spaceId, root->typeId);
+    }
+  };
+
+} // namespace h5hep
+
+#endif // _H5HEP_MODEL_COMPOUNDTYPE_HXX

--- a/root/tree/tree/h5hep/h5hep/schema.hxx
+++ b/root/tree/tree/h5hep/h5hep/schema.hxx
@@ -51,7 +51,7 @@ namespace h5hep {
 
       NodeBase(const NodeBase &) = default;
       NodeBase(NodeKind k, std::string_view name, size_t offset, size_t size, hid_t tid)
-	: kind(k), name(name), offset(offset), size(size), typeId(tid) {}
+        : kind(k), name(name), offset(offset), size(size), typeId(tid) {}
       virtual ~NodeBase() {}
 
       /// \brief Called by a ReaderWriter during construction to perform initialization that requires
@@ -60,9 +60,9 @@ namespace h5hep {
       /// \param rw The `ReaderWriter` instance realizing the schema
       /// \param privateData Reserved for private use of the column model implementation
       virtual void Realize(ReaderWriter &rw, void *privateData) {
-	readerWriter = &rw;
-	for (auto &I : children)
-	  I->Realize(rw, privateData);
+        readerWriter = &rw;
+        for (auto &I : children)
+          I->Realize(rw, privateData);
       }
 
       /// \brief Initialize the value pointed to by `p` of this type. This is typically a no-op for primitive
@@ -108,7 +108,7 @@ namespace h5hep {
 
       template <typename T>
       static std::shared_ptr<StructNode<M, T>> MakeStructNode(std::string_view name, size_t offset,
-							      typename StructNode<M, T>::MemberList_t &&v)
+                                                              typename StructNode<M, T>::MemberList_t &&v)
       { return std::make_shared<StructNode<M, T>>(name, offset, v); }
 
       template <typename T>
@@ -117,7 +117,7 @@ namespace h5hep {
 
       template <typename T>
       static std::shared_ptr<CollectionNode<M, typename T::Value_t>> MakeCollectionNode(std::string_view name, size_t offset,
-								      std::shared_ptr<T> inner)
+                                                                      std::shared_ptr<T> inner)
       { return std::make_shared<CollectionNode<M, typename T::Value_t>>(name, offset, inner); }
 
       template <typename... Ts>

--- a/root/tree/tree/h5hep/h5hep/schema.hxx
+++ b/root/tree/tree/h5hep/h5hep/schema.hxx
@@ -1,0 +1,131 @@
+/// \file h5hep/schema.hxx
+/// \author Javier Lopez-Gomez <j.lopez@cern.ch>
+/// \date 2021-10-23
+///
+/// \brief Header-only library to read/write high-energy physics data in HDF5.
+/// For benchmark purposes only; do NOT use in production.
+
+#ifndef _H5HEP_SCHEMA_HXX
+#define _H5HEP_SCHEMA_HXX
+
+#include <h5hep/common.hxx>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace h5hep {
+
+  /// \brief The column model defines how schema columns are translated to HDF5.
+  enum class ColumnModel {
+    /// \brief Uses (possibly nested) compound types to represent data for each row.
+    COMPOUND_TYPE = 0,
+
+    /// \brief Uses one HDF5 dataset per primitive column; collections are translated to
+    /// a HDF5 group and a index column. For more information, see
+    /// https://inspirehep.net/files/e048b0cd122919dc9a009793983a81e0.
+    COLUMNAR_FNAL,
+
+    UNKNOWN = 99
+  };
+
+  class ReaderWriter;
+  template <ColumnModel M> class ReaderWriterSpec;
+
+  namespace schema {
+    enum class NodeKind {
+      PRIMITIVE = 0, 
+      STRUCT,
+      COLLECTION,
+    };
+
+    struct NodeBase {
+      NodeKind kind;
+      std::string name;
+      size_t offset; /// \brief Offset of this member within the enclosing type
+      size_t size;   /// \brief Size of the datatype
+      hid_t typeId;  /// \brief HDF5 type id for this node, if any
+      std::vector<std::shared_ptr<NodeBase>> children;
+      ReaderWriter *readerWriter{}; /// \brief Related `ReaderWriter` object, if the schema has been realized
+
+      NodeBase(const NodeBase &) = default;
+      NodeBase(NodeKind k, std::string_view name, size_t offset, size_t size, hid_t tid)
+	: kind(k), name(name), offset(offset), size(size), typeId(tid) {}
+      virtual ~NodeBase() {}
+
+      /// \brief Called by a ReaderWriter during construction to perform initialization that requires
+      /// an HDF5 file handle, e.g. to create datasets/groups.
+      ///
+      /// \param rw The `ReaderWriter` instance realizing the schema
+      /// \param privateData Reserved for private use of the column model implementation
+      virtual void Realize(ReaderWriter &rw, void *privateData) {
+	readerWriter = &rw;
+	for (auto &I : children)
+	  I->Realize(rw, privateData);
+      }
+
+      /// \brief Initialize the value pointed to by `p` of this type. This is typically a no-op for primitive
+      /// types; non-scalar types require it though.
+      virtual void InitializeValue(void *p) {}
+
+      /// \brief Read the rows described by `extents` into `buf`. The caller must provide a
+      /// buffer that is large enough to copy all the data.
+      virtual size_t ReadExtents(const std::vector<Span> &extents, void *buf) = 0;
+      /// \brief Write the rows pointed to by `buf` using the layout described by `extents`.
+      virtual size_t WriteExtents(const std::vector<Span> &extents, const void *buf) = 0;
+
+      virtual std::shared_ptr<NodeBase> Clone() const = 0;
+    };
+
+    template <ColumnModel M> class Node;
+
+    /// \brief A field of a fundamental type `T`, e.g. 'double'. The mapping of a PrimitiveNode
+    /// to HDF5 depends on the column model.
+    template <ColumnModel M, typename T> class PrimitiveNode;
+
+    /// \brief A group of `PrimitiveNode` or `CollectionNode` fields. The mapping of a StructNode
+    /// to HDF5 depends on the column model.
+    template <ColumnModel M, typename T> class StructNode;
+
+    /// \brief A variable-length collection of any type `T`. The mapping of a CollectionNode to HDF5
+    /// depends on the column model.
+    template <ColumnModel M, typename T> class CollectionNode;
+
+    /// \brief Provides access to convenience functions for building schema nodes, e.g.
+    /// ```
+    /// using Builder = h5hep::schema::SchemaBuilder<h5hep::ColumnModel::COMPOUND_TYPE>
+    /// auto root = Builder::MakeStructNode<Foo>("Foo", {
+    ///   })
+    /// ```
+    template <ColumnModel M>
+    struct SchemaBuilder {
+      static constexpr ColumnModel GetColumnModel() { return M; }
+
+      template <typename T>
+      static std::shared_ptr<PrimitiveNode<M, T>> MakePrimitiveNode(std::string_view name = "(anonymous)", size_t offset = 0)
+      { return std::make_shared<PrimitiveNode<M, T>>(name, offset); }
+
+      template <typename T>
+      static std::shared_ptr<StructNode<M, T>> MakeStructNode(std::string_view name, size_t offset,
+							      typename StructNode<M, T>::MemberList_t &&v)
+      { return std::make_shared<StructNode<M, T>>(name, offset, v); }
+
+      template <typename T>
+      static std::shared_ptr<StructNode<M, T>> MakeStructNode(std::string_view name, typename StructNode<M, T>::MemberList_t &&v)
+      { return std::make_shared<StructNode<M, T>>(name, 0UL, v); }
+
+      template <typename T>
+      static std::shared_ptr<CollectionNode<M, typename T::Value_t>> MakeCollectionNode(std::string_view name, size_t offset,
+								      std::shared_ptr<T> inner)
+      { return std::make_shared<CollectionNode<M, typename T::Value_t>>(name, offset, inner); }
+
+      template <typename... Ts>
+      static std::shared_ptr<ReaderWriterSpec<M>> MakeReaderWriter(Ts... args)
+      { return std::make_shared<ReaderWriterSpec<M>>(args...); }
+    };
+  } // namespace schema
+
+} // namespace h5hep
+
+#endif // _H5HEP_SCHEMA_HXX


### PR DESCRIPTION
This pull request integrates into rootbench a header-only library to read/write simple HEP data in HDF5.  
Having this at hand here would allow comparison benchmarks against HDF5 to be added in the future. 

The library allows the storage of simple HEP data in HDF5, hiding away the details of data representation. Currently, it supports two different column models:
- `COMPOUND_TYPE`: that uses (possibly nested) compound types to represent data for each row.
- `COLUMNAR_FNAL`: uses one HDF5 dataset per column of a primitive type.  Collections are translated to a HDF5 group and an index column.  For more information about this model, see the publication by Saba Sehrish et al. [here](https://inspirehep.net/files/e048b0cd122919dc9a009793983a81e0).

THIS CODE IS FOR BENCHMARK PURPOSES ONLY (ORIGINALLY FOR ACAT 2021); DO NOT USE IN PRODUCTION.

This is the state after ACAT 2021; however, in this or a follow-up PR we need to:
- [ ] Improve doxygen documentation
- [ ] Add tests

## Example
The Makefile in the `examples/` directory generates two versions of `simple_struct.cxx`: `simple_struct_compound` and `simple_struct_fnal`.  Both of them will generate the same output; however, the internal HDF5 representation is basically different, as shown below.

For more complex examples, see [gen_lhcb_h5.cc](https://github.com/jalopezg-r00t/iotools/blob/ACAT21/compare/gen_lhcb_h5.cc), [gen_cms_h5.cc](https://github.com/jalopezg-r00t/iotools/blob/ACAT21/compare/gen_cms_h5.cc), [lhcb_h5.cc](https://github.com/jalopezg-r00t/iotools/blob/ACAT21/compare/lhcb_h5.cc), and [cms_10br_h5.cc](https://github.com/jalopezg-r00t/iotools/blob/ACAT21/compare/cms_10br_h5.cc) (not in this PR).

```bash
$ # For ./simple_struct_compound
$ h5dump simple_struct.h5
HDF5 "simple_struct.h5" {
GROUP "/" {
   DATASET "Foo" {
      DATATYPE  H5T_COMPOUND {
         H5T_STD_I32LE "i";
         H5T_IEEE_F32LE "f";
         H5T_VLEN { H5T_COMPOUND {
            H5T_IEEE_F32LE "f1";
            H5T_IEEE_F32LE "f2";
         }} "c";
      }
      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
      DATA {
      (0): {
            0,
            1.2345,
            ({
                  1.1,
                  1.2
               }, {
                  2.1,
                  2.2
               }, {
                  3.1,
                  3.2
               })
         },
...
$ # For ./simple_struct_fnal
$ h5dump simple_struct.h5
HDF5 "simple_struct.h5" {
GROUP "/" {
   ATTRIBUTE "$Metadata" {
      DATATYPE  H5T_STD_U64LE
      DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
      DATA {
      (0): 4, 4
      }
   }
   GROUP "c" {
      DATASET "Event ID" {
         DATATYPE  H5T_STD_U64LE
         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
         DATA {
         (0): 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3
         }
      }
      DATASET "f1" {
         DATATYPE  H5T_IEEE_F32LE
         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
         DATA {
         (0): 1.1, 2.1, 3.1, 1.1, 2.1, 3.1, 1.1, 2.1, 3.1, 1.1, 2.1, 3.1
         }
      }
      DATASET "f2" {
         DATATYPE  H5T_IEEE_F32LE
         DATASPACE  SIMPLE { ( 12 ) / ( H5S_UNLIMITED ) }
         DATA {
         (0): 1.2, 2.2, 3.2, 1.2, 2.2, 3.2, 1.2, 2.2, 3.2, 1.2, 2.2, 3.2
         }
      }
   }
   DATASET "f" {
      DATATYPE  H5T_IEEE_F32LE
      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
      DATA {
      (0): 1.2345, 2.2345, 3.2345, 4.2345
      }
   }
   DATASET "i" {
      DATATYPE  H5T_STD_I32LE
      DATASPACE  SIMPLE { ( 4 ) / ( H5S_UNLIMITED ) }
      DATA {
      (0): 0, 1, 2, 3
      }
   }
}
}
```