### PR TITLE
[RF] Add HistFactory benchmark based of `hf001_example` tutorial

### DIFF
--- a/root/roofit/CMakeLists.txt
+++ b/root/roofit/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(histfactory)
 add_subdirectory(roofit)
 add_subdirectory(vectorisedPDFs)

--- a/root/roofit/histfactory/CMakeLists.txt
+++ b/root/roofit/histfactory/CMakeLists.txt
@@ -1,0 +1,5 @@
+RB_ADD_GBENCHMARK(benchHistFactory
+  benchHistFactory.cxx
+  TestWorkspaces.cxx
+  LABEL long
+  LIBRARIES Core Hist MathCore RIO RooFit RooStats RooFitCore HistFactory)

--- a/root/roofit/histfactory/TestWorkspaces.cxx
+++ b/root/roofit/histfactory/TestWorkspaces.cxx
@@ -1,0 +1,85 @@
+#include "TestWorkspaces.h"
+
+#include <RooMsgService.h>
+#include <RooStats/HistFactory/MakeModelAndMeasurementsFast.h>
+
+#include <TROOT.h>
+#include <TSystem.h>
+
+#include <iostream>
+#include <string>
+
+/// Returns the workspace that is also created in the hf001_example.C tutorial.
+/// Note that running this function creates a directory `hf001_data` in the
+/// current directory.
+RooWorkspace *
+TestWorkspaces::getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration const &cfg)
+{
+   using namespace RooStats::HistFactory;
+
+   const std::string inputFile = "./hf001/data/example.root";
+   // in case the file is not found
+   if (bool bfile = gSystem->AccessPathName(inputFile.c_str())) {
+      std::cout << "Input file is not found - run prepareHistFactory script " << std::endl;
+      gROOT->ProcessLine("mkdir -p hf001");
+      gROOT->ProcessLine(".! prepareHistFactory hf001");
+      bfile = gSystem->AccessPathName(inputFile.c_str());
+      if (bfile) {
+         std::cout << "Still no " << inputFile << ", giving up.\n";
+         exit(1);
+      }
+   }
+
+   // Create the measurement
+   Measurement meas("meas", "meas");
+
+   meas.SetOutputFilePrefix("./results/example_UsingC");
+   meas.SetPOI("SigXsecOverSM");
+   meas.AddConstantParam("alpha_syst1");
+   meas.AddConstantParam("Lumi");
+
+   meas.SetLumi(1.0);
+   meas.SetLumiRelErr(0.10);
+   meas.SetExportOnly(false);
+   meas.SetBinHigh(2);
+
+   // Create a channel
+
+   Channel chan("channel1");
+   chan.SetData("data", inputFile);
+   chan.SetStatErrorConfig(0.05, "Poisson");
+
+   // Now, create some samples
+
+   // Create the signal sample
+   Sample signal("signal", "signal", inputFile);
+   signal.AddOverallSys("syst1", 0.95, 1.05);
+   signal.AddNormFactor("SigXsecOverSM", 1, 0, 3);
+   chan.AddSample(signal);
+
+   // Background 1
+   Sample background1("background1", "background1", inputFile);
+   background1.ActivateStatError("background1_statUncert", inputFile);
+   background1.AddOverallSys("syst2", 0.95, 1.05);
+   chan.AddSample(background1);
+
+   // Background 1
+   Sample background2("background2", "background2", inputFile);
+   background2.ActivateStatError();
+   background2.AddOverallSys("syst3", 0.95, 1.05);
+   chan.AddSample(background2);
+
+   // Done with this channel
+   // Add it to the measurement:
+   meas.AddChannel(chan);
+
+   // Collect the histograms from their files,
+   // print some output,
+   meas.CollectHistograms();
+   meas.PrintTree(oocoutI(nullptr, HistFactory));
+
+   meas.SetExportOnly(true);
+
+   // Now, do the measurement
+   return MakeModelAndMeasurementFast(meas, cfg);
+}

--- a/root/roofit/histfactory/TestWorkspaces.h
+++ b/root/roofit/histfactory/TestWorkspaces.h
@@ -1,0 +1,14 @@
+#ifndef TestWorkspaces_h
+#define TestWorkspaces_h
+
+#include <RooStats/HistFactory/HistoToWorkspaceFactoryFast.h>
+
+class RooWorkspace;
+
+namespace TestWorkspaces {
+
+RooWorkspace *getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration const &cfg);
+
+} // namespace TestWorkspaces
+
+#endif

--- a/root/roofit/histfactory/benchHistFactory.cxx
+++ b/root/roofit/histfactory/benchHistFactory.cxx
@@ -1,0 +1,56 @@
+#include <RooWorkspace.h>
+#include <RooMinimizer.h>
+#include <RooMsgService.h>
+#include <RooStats/ModelConfig.h>
+
+#include "TestWorkspaces.h"
+
+#include <benchmark/benchmark.h>
+
+/// Benchmark the hf001_example from the HistFactory tutorials.
+static void benchHistFactory001(benchmark::State &state)
+{
+   auto &msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(RooFit::WARNING);
+
+   using namespace RooFit;
+
+   RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration hfCfg;
+   hfCfg.binnedFitOptimization = state.range(0);
+   auto *w = TestWorkspaces::getWorkspace001(hfCfg);
+
+   auto *mc = static_cast<RooStats::ModelConfig *>(w->obj("ModelConfig"));
+
+   RooArgSet params;
+   if (mc->GetParametersOfInterest())
+      params.add(*mc->GetParametersOfInterest());
+   if (mc->GetNuisanceParameters())
+      params.add(*mc->GetNuisanceParameters());
+
+   auto *pdf = w->pdf("simPdf");
+   auto *mu = w->var("SigXsecOverSM");
+
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*w->data("obsData"), Constrain(params),
+                                                  GlobalObservables(*mc->GetGlobalObservables()),
+                                                  BatchMode(state.range(1)))};
+   RooArgSet parameters{};
+   RooArgSet initialParameters{};
+   nll->getParameters(nullptr, parameters);
+   parameters.snapshot(initialParameters);
+
+   RooMinimizer m(*nll);
+   m.setPrintLevel(-1);
+
+   for (auto _ : state) {
+      m.minimize("Minuit2");
+   }
+}
+
+auto const unit = benchmark::kMillisecond;
+
+BENCHMARK(benchHistFactory001)->Unit(unit)->Args({1, 0})->Name("hf001__BinnedFitOptimization_ON___BatchMode_OFF");
+BENCHMARK(benchHistFactory001)->Unit(unit)->Args({0, 0})->Name("hf001__BinnedFitOptimization_OFF__BatchMode_OFF");
+BENCHMARK(benchHistFactory001)->Unit(unit)->Args({1, 1})->Name("hf001__BinnedFitOptimization_ON___BatchMode_ON_");
+BENCHMARK(benchHistFactory001)->Unit(unit)->Args({0, 1})->Name("hf001__BinnedFitOptimization_OFF__BatchMode_ON_");
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This is a follow up to https://github.com/root-project/root/pull/10562.

The benchmark measures the fit time for the model from the `hf001_example` tutorial.

Right now, the benchmark output looks as follows:

```
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
hf001__BinnedFitOptimization_ON___BatchMode_OFF/1/0      0.180 ms        0.180 ms         3925
hf001__BinnedFitOptimization_OFF__BatchMode_OFF/0/0       1.25 ms         1.25 ms          553
hf001__BinnedFitOptimization_ON___BatchMode_ON_/1/1       1.29 ms         1.29 ms          518
hf001__BinnedFitOptimization_OFF__BatchMode_ON_/0/1       1.30 ms         1.29 ms          521
```

After merging the PR with the binned fit optimization in the BatchMode (https://github.com/root-project/root/pull/9423), the timings with the batch mode should reduce significantly.