### PR TITLE
[RF] Include BatchMode CPU and CUDA in RooFit unbinned benchmarks

### DIFF
--- a/root/roofit/vectorisedPDFs/benchAddPdf.cxx
+++ b/root/roofit/vectorisedPDFs/benchAddPdf.cxx
@@ -243,11 +243,15 @@ BENCHMARK(benchEvalUser)->Unit(benchmark::kMillisecond)->Name("benchAddPddWithUs
 
 BENCHMARK(benchFit)->Unit(benchmark::kMillisecond)->Name("benchAddPdf_FitScalar")->Args({fitScalar});
 BENCHMARK(benchFit)->Unit(benchmark::kMillisecond)->Name("benchAddPdf_FitBatchCPU")->Args({fitCpu});
-// BENCHMARK(benchFit)->Unit(benchmark::kMillisecond)->Name("benchAddPdf_FitBatchCUDA")->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchFit)->Unit(benchmark::kMillisecond)->Name("benchAddPdf_FitBatchCUDA")->Args({fitCuda});
+#endif
 
 BENCHMARK(benchFitUser)->Unit(benchmark::kMillisecond)->Name("benchAddPdfWithUserExp_FitScalar")->Args({fitScalar});
 BENCHMARK(benchFitUser)->Unit(benchmark::kMillisecond)->Name("benchAddPdfWithUserExp_FitBatchCPU")->Args({fitCpu});
-// BENCHMARK(benchFitUser)->Unit(benchmark::kMillisecond)->Name("benchAddPdfWithUserExp_FitBatchCUDA")->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchFitUser)->Unit(benchmark::kMillisecond)->Name("benchAddPdfWithUserExp_FitBatchCUDA")->Args({fitCuda});
+#endif
 
 // BENCHMARK_MAIN();
 

--- a/root/roofit/vectorisedPDFs/benchFitModel.cxx
+++ b/root/roofit/vectorisedPDFs/benchFitModel.cxx
@@ -114,6 +114,8 @@ BENCHMARK(benchModel)->Name("fit_Scalar")->Unit(benchmark::kMillisecond)->Args({
 
 BENCHMARK(benchModel)->Name("fit_CPU")->Unit(benchmark::kMillisecond)->Args({fitCpu});
 
-//BENCHMARK(benchModel)->Name("fit_CUDA")->Unit(benchmark::kMillisecond)->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchModel)->Name("fit_CUDA")->Unit(benchmark::kMillisecond)->Args({fitCuda});
+#endif
 
 BENCHMARK_MAIN();

--- a/root/roofit/vectorisedPDFs/benchGauss.cxx
+++ b/root/roofit/vectorisedPDFs/benchGauss.cxx
@@ -214,18 +214,26 @@ static void benchFitGaussXSigma(benchmark::State &state)
 
 BENCHMARK(benchEvalGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_EvalScalar")->Args({runScalar});
 BENCHMARK(benchEvalGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_EvalBatchCPU")->Args({runCpu});
-// BENCHMARK(benchEvalGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_EvalBatchCUDA")->Args({runCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchEvalGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_EvalBatchCUDA")->Args({runCuda});
+#endif
 
 BENCHMARK(benchEvalGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_EvalScalar")->Args({runScalar});
 BENCHMARK(benchEvalGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_EvalBatchCPU")->Args({runCpu});
-// BENCHMARK(benchEvalGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_EvalBatchCUDA")->Args({runCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchEvalGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_EvalBatchCUDA")->Args({runCuda});
+#endif
 
 BENCHMARK(benchFitGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_FitScalar")->Args({fitScalar});
 BENCHMARK(benchFitGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_FitBatchCPU")->Args({fitCpu});
-// BENCHMARK(benchFitGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_FitBatchCUDA")->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchFitGauss)->Unit(benchmark::kMillisecond)->Name("benchGaus_FitBatchCUDA")->Args({fitCuda});
+#endif
 
 BENCHMARK(benchFitGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_FitScalar")->Args({fitScalar});
 BENCHMARK(benchFitGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_FitBatchCPU")->Args({fitCpu});
-// BENCHMARK(benchFitGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_FitBatchCUDA")->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchFitGaussXSigma)->Unit(benchmark::kMillisecond)->Name("benchGausXS_FitBatchCUDA")->Args({fitCuda});
+#endif
 
 BENCHMARK_MAIN();

--- a/root/roofit/vectorisedPDFs/benchProdPdf.cxx
+++ b/root/roofit/vectorisedPDFs/benchProdPdf.cxx
@@ -125,6 +125,8 @@ BENCHMARK(benchProdPdf)->Name("fit_Scalar")->Unit(benchmark::kMillisecond)->Args
 
 BENCHMARK(benchProdPdf)->Name("fit_CPU")->Unit(benchmark::kMillisecond)->Args({fitCpu});
 
-//BENCHMARK(benchProdPdf)->Name("fit_CUDA")->Unit(benchmark::kMillisecond)->Args({fitCuda});
+#ifdef R__HAS_CUDA
+BENCHMARK(benchProdPdf)->Name("fit_CUDA")->Unit(benchmark::kMillisecond)->Args({fitCuda});
+#endif
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
The RooFit unbinned benchmark is updated because the target for CHEP is to fully support it on the GPU.