### PR TITLE
[RF] Reset parameters before fitting in `vectorizedPDFs` benchmarks

### DIFF
--- a/root/roofit/vectorisedPDFs/benchFitModel.cxx
+++ b/root/roofit/vectorisedPDFs/benchFitModel.cxx
@@ -29,38 +29,18 @@
  *
  */
 
-#include <benchmark/benchmark.h>
+#include "helpers.h"
 
 #include <RooWorkspace.h>
-#include <RooAbsPdf.h>
-#include <RooRealVar.h>
 #include <RooDataSet.h>
-#include <RooRandom.h>
-
-void randomiseParameters(const RooArgSet &parameters, ULong_t seed = 0)
-{
-   auto random = RooRandom::randomGenerator();
-   if (seed != 0)
-      random->SetSeed(seed);
-
-   for (auto param : parameters) {
-      auto par = static_cast<RooAbsRealLValue *>(param);
-      const double uni = random->Uniform();
-      const double min = par->getMin();
-      const double max = par->getMax();
-      par->setVal(min + uni * (max - min));
-   }
-}
-
-enum RunConfig_t { fitScalar, fitCpu, fitCuda };
 
 static void benchModel(benchmark::State &state)
 {
    RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
 
    const RunConfig_t runConfig = static_cast<RunConfig_t>(state.range(0));
-   //const int printLevel = state.range(1);
-   //const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
+   // const int printLevel = state.range(1);
+   // const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
    const std::size_t nEvents = 100000;
 
    // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
@@ -68,7 +48,7 @@ static void benchModel(benchmark::State &state)
    RooWorkspace w;
    //  w.factory("Voigtian::vpdf(x[-10,10],m0[0,-10,10],width[0.5,0,10],s0[0.5,0,10])");
    //  w.factory("Gaussian::vpdf(x[0,20],m0[10,0,20],s0[0.5,0,10])");
-   w.factory("Gamma::vpdf(x[0,20],g[20,0.1,40],b[0.5,0.01,10],m0[0])");
+   w.factory("Gamma::vpdf(x[0,20],g[20,0.1,40],b[0.5,0.01,10],m0[-1,-20,0])");
    w.factory("Gaussian::gpdf(x,m1[10,0,20],s1[2,0.1,10])");
    w.factory("Gaussian::g2(x,m2[5,0,20],s2[0.3,0.01,10])");
    w.factory("Gaussian::g3(x,m3[15,0,20],s3[0.4,0.01,10])");
@@ -87,27 +67,22 @@ static void benchModel(benchmark::State &state)
    auto &pdf = *(w.pdf("model"));
    auto &x = *(w.var("x"));
 
-   std::unique_ptr<RooDataSet> data{pdf.generate(RooArgSet(x), nEvents)};
+   std::unique_ptr<RooDataSet> data{pdf.generate({x}, nEvents)};
 
-   // RooArgSet& observables = *pdf.getObservables(data);
-   // RooArgSet& parameters = *pdf.getParameters(data);
-
-   // std::array<RooArgSet, nParamSets> paramSets;
-   // unsigned int seed = 1337;
-   // for (auto& paramSet : paramSets) {
-   //   randomiseParameters(parameters, seed++);
-   //   parameters.snapshot(paramSet);
-   // }
-
-   for (auto _ : state) {
-      if (runConfig == fitScalar) {
-         pdf.fitTo(*data, RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      } else if (runConfig == fitCpu) {
-         pdf.fitTo(*data, RooFit::BatchMode("cpu"), RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      } else if (runConfig == fitCuda) {
-         pdf.fitTo(*data, RooFit::BatchMode("cuda"), RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      }
+   RooArgSet parameters;
+   pdf.getParameters(data->get(), parameters);
+   // We need to change the parameters so we don't start already at the minimum
+   // (the parameter values for which the dataset was created). This time, we
+   // don't randomize them because the fit has many parameter and is not stable
+   // from many initial points. That's why they are only shifted away a little
+   // bit from their true value.
+   for (auto *param : static_range_cast<RooRealVar *>(parameters)) {
+      double val = param->getVal();
+      val = val + 0.05 * (param->getMax() - val);
+      param->setVal(val);
    }
+
+   runFitBenchmark(state, pdf, *data);
 }
 
 BENCHMARK(benchModel)->Name("fit_Scalar")->Unit(benchmark::kMillisecond)->Args({fitScalar});

--- a/root/roofit/vectorisedPDFs/benchProdPdf.cxx
+++ b/root/roofit/vectorisedPDFs/benchProdPdf.cxx
@@ -29,30 +29,11 @@
  *
  */
 
-#include <benchmark/benchmark.h>
+#include "helpers.h"
 
 #include <RooWorkspace.h>
 #include <RooAbsPdf.h>
-#include <RooRealVar.h>
 #include <RooDataSet.h>
-#include <RooRandom.h>
-
-void randomiseParameters(const RooArgSet &parameters, ULong_t seed = 0)
-{
-   auto random = RooRandom::randomGenerator();
-   if (seed != 0)
-      random->SetSeed(seed);
-
-   for (auto param : parameters) {
-      auto par = static_cast<RooAbsRealLValue *>(param);
-      const double uni = random->Uniform();
-      const double min = par->getMin();
-      const double max = par->getMax();
-      par->setVal(min + uni * (max - min));
-   }
-}
-
-enum RunConfig_t { fitScalar, fitCpu, fitCuda };
 
 constexpr bool verbose = false;
 bool first = true;
@@ -62,8 +43,8 @@ static void benchProdPdf(benchmark::State &state)
    RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
 
    const RunConfig_t runConfig = static_cast<RunConfig_t>(state.range(0));
-   //const int printLevel = state.range(1);
-   //const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
+   // const int printLevel = state.range(1);
+   // const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
    const std::size_t nEvents = 100000;
 
    // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
@@ -73,7 +54,7 @@ static void benchProdPdf(benchmark::State &state)
    w.factory("Gaussian::g2(x,mx2[10,0,20],sx2[1,0.1,10])");
    w.factory("Gaussian::g3(y[0,20],my[10,0,20],sy[2,0.1,10])");
    w.factory("Polynomial::pol(y,a[-0.01,-0.05,0.1])");
-   w.factory("Gamma::gpdf(z[0,10],g[2,0.1,10],b[2,0.1,10],m0[0])");
+   w.factory("Gamma::gpdf(z[0,10],g[2,0.1,10],b[2,0.1,10],m0[-1,-20,0])");
 
    w.factory("SUM::pdfx(fx[0.2,0,1]*g1,g2)");
    w.factory("SUM::pdfy(fy[0.4,0.,1.]*g3,pol)");
@@ -98,27 +79,22 @@ static void benchProdPdf(benchmark::State &state)
    auto &y = *(w.var("y"));
    auto &z = *(w.var("z"));
 
-   std::unique_ptr<RooDataSet> data{pdf.generate(RooArgSet(x, y, z), nEvents)};
+   std::unique_ptr<RooDataSet> data{pdf.generate({x, y, z}, nEvents)};
 
-   // RooArgSet& observables = *pdf.getObservables(data);
-   // RooArgSet& parameters = *pdf.getParameters(data);
-
-   // std::array<RooArgSet, nParamSets> paramSets;
-   // unsigned int seed = 1337;
-   // for (auto& paramSet : paramSets) {
-   //   randomiseParameters(parameters, seed++);
-   //   parameters.snapshot(paramSet);
-   // }
-
-   for (auto _ : state) {
-      if (runConfig == fitScalar) {
-         pdf.fitTo(*data, RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      } else if (runConfig == fitCpu) {
-         pdf.fitTo(*data, RooFit::BatchMode("cpu"), RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      } else if (runConfig == fitCuda) {
-         pdf.fitTo(*data, RooFit::BatchMode("cuda"), RooFit::Minimizer("Minuit2"), RooFit::PrintLevel(-1));
-      }
+   RooArgSet parameters;
+   pdf.getParameters(data->get(), parameters);
+   // We need to change the parameters so we don't start already at the minimum
+   // (the parameter values for which the dataset was created). This time, we
+   // don't randomize them because the fit has many parameter and is not stable
+   // from many initial points. That's why they are only shifted away a little
+   // bit from their true value.
+   for (auto *param : static_range_cast<RooRealVar *>(parameters)) {
+      double val = param->getVal();
+      val = val + 0.05 * (param->getMax() - val);
+      param->setVal(val);
    }
+
+   runFitBenchmark(state, pdf, *data);
 }
 
 BENCHMARK(benchProdPdf)->Name("fit_Scalar")->Unit(benchmark::kMillisecond)->Args({fitScalar});

--- a/root/roofit/vectorisedPDFs/helpers.h
+++ b/root/roofit/vectorisedPDFs/helpers.h
@@ -1,0 +1,49 @@
+#include <RooAbsPdf.h>
+#include <RooAbsData.h>
+#include <RooRandom.h>
+#include <RooRealVar.h>
+
+#include <benchmark/benchmark.h>
+
+int printLevel = 0;
+
+enum RunConfig_t { runScalar, runCpu, fitScalar, fitCpu, fitCuda };
+
+void runFitBenchmark(benchmark::State &state, RooAbsPdf &pdf, RooAbsData &data)
+{
+   RunConfig_t runConfig = static_cast<RunConfig_t>(state.range(0));
+
+   RooArgSet params;
+   pdf.getParameters(data.get(), params);
+   RooArgSet paramsInitial;
+   params.snapshot(paramsInitial);
+
+   using namespace RooFit;
+   for (auto _ : state) {
+      if (runConfig == fitScalar) {
+         pdf.fitTo(data, BatchMode("off"), Minimizer("Minuit2"), PrintLevel(printLevel - 1));
+      } else if (runConfig == fitCpu) {
+         pdf.fitTo(data, BatchMode("cpu"), Minimizer("Minuit2"), PrintLevel(printLevel - 1));
+      } else if (runConfig == fitCuda) {
+         pdf.fitTo(data, BatchMode("cuda"), Minimizer("Minuit2"), PrintLevel(printLevel - 1));
+      }
+      state.PauseTiming();
+      params.assign(paramsInitial);
+      state.ResumeTiming();
+   }
+}
+
+void randomiseParameters(const RooArgSet &parameters, ULong_t seed = 0)
+{
+   auto random = RooRandom::randomGenerator();
+   if (seed != 0)
+      random->SetSeed(seed);
+
+   for (auto param : parameters) {
+      auto par = static_cast<RooAbsRealLValue *>(param);
+      const double uni = random->Uniform();
+      const double min = par->getMin();
+      const double max = par->getMax();
+      par->setVal(min + uni * (max - min));
+   }
+}


### PR DESCRIPTION
Before benchmarking a likelihood minimization, the model parameters need to be reset to something away from the parameters that were used to generate the toy dataset. Otherwise, the fit is starting already at the minimium and we won't benchmark the actual minimization path.

Furthermore, the parameters need to be reset after each benchmark iteration.