### PR TITLE
Avoid compiler warnings when building `rootbench`

### DIFF
--- a/root/io/io/TBufferMergerBenchmarks.cxx
+++ b/root/io/io/TBufferMergerBenchmarks.cxx
@@ -92,7 +92,7 @@ static void BM_TBufferFile_FillTreeWithRandomData(benchmark::State &state)
       // Setup code here.
       Merger = new TBufferMerger(std::make_unique<TMemFile>("virtual_file.root", "RECREATE"));
    }
-   long size;
+   long size = 0;
    int flush = state.range(0);
    for (auto _ : state) {
       FillTreeWithRandomData(*Merger, flush);

--- a/root/roofit/roofit/benchCodeSquashAD.cxx
+++ b/root/roofit/roofit/benchCodeSquashAD.cxx
@@ -87,16 +87,16 @@ static void BM_RooFuncWrapper_ManyParams_Minimization(benchmark::State &state)
 
    auto nChannels = state.range(1);
 
-   for (std::size_t i = 0; i < nChannels; ++i) {
-      std::string suffix = "_" + std::to_string(i + 1);
+   for (int iChannel = 0; iChannel < nChannels; ++iChannel) {
+      std::string suffix = "_" + std::to_string(iChannel + 1);
       auto obsName = "x" + suffix;
       auto x = std::make_unique<RooRealVar>(obsName.c_str(), obsName.c_str(), 0, 10.);
       x->setBins(20);
 
-      std::unique_ptr<RooAbsPdf> model{createModel(*x, std::to_string(i + 1))};
+      std::unique_ptr<RooAbsPdf> model{createModel(*x, std::to_string(iChannel + 1))};
 
       pdfMap.insert({"channel" + suffix, model.get()});
-      channelCat.defineType("channel" + suffix, i);
+      channelCat.defineType("channel" + suffix, iChannel);
       dataMap.insert({"channel" + suffix, std::unique_ptr<RooAbsData>{model->generateBinned(*x, nEvents)}});
 
       observables.addOwned(std::move(x));

--- a/root/roofit/roofit/benchRooFitBackends.cxx
+++ b/root/roofit/roofit/benchRooFitBackends.cxx
@@ -56,10 +56,6 @@ static void benchProdPdf(benchmark::State &state)
 {
    RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
 
-   const RunConfig_t runConfig = static_cast<RunConfig_t>(state.range(0));
-   // const int printLevel = state.range(1);
-   // const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
-
    // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
 
    RooWorkspace w;
@@ -271,10 +267,6 @@ static void benchFit(benchmark::State &state)
 static void benchModel(benchmark::State &state)
 {
    RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
-
-   const RunConfig_t runConfig = static_cast<RunConfig_t>(state.range(0));
-   // const int printLevel = state.range(1);
-   // const int nParamSets = 1; // state.range(2) > 1 : state.range(2) ? 1;
 
    // Declare variables x,mean,sigma with associated name, title, initial value and allowed range
 


### PR DESCRIPTION
Avoid compiler warnings when building `rootbench`.