### PR TITLE
[RF] Replace RooFit legacy iterators and make code compile also with memory safe mode

### DIFF
--- a/root/roofit/histfactory/TestWorkspaces.cxx
+++ b/root/roofit/histfactory/TestWorkspaces.cxx
@@ -12,7 +12,7 @@
 /// Returns the workspace that is also created in the hf001_example.C tutorial.
 /// Note that running this function creates a directory `hf001_data` in the
 /// current directory.
-RooWorkspace *
+std::unique_ptr<RooWorkspace>
 TestWorkspaces::getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration const &cfg)
 {
    using namespace RooStats::HistFactory;
@@ -81,5 +81,5 @@ TestWorkspaces::getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFa
    meas.SetExportOnly(true);
 
    // Now, do the measurement
-   return MakeModelAndMeasurementFast(meas, cfg);
+   return std::unique_ptr<RooWorkspace>{MakeModelAndMeasurementFast(meas, cfg)};
 }

--- a/root/roofit/histfactory/TestWorkspaces.h
+++ b/root/roofit/histfactory/TestWorkspaces.h
@@ -3,11 +3,14 @@
 
 #include <RooStats/HistFactory/HistoToWorkspaceFactoryFast.h>
 
+#include <memory>
+
 class RooWorkspace;
 
 namespace TestWorkspaces {
 
-RooWorkspace *getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration const &cfg);
+std::unique_ptr<RooWorkspace>
+getWorkspace001(RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration const &cfg);
 
 } // namespace TestWorkspaces
 

--- a/root/roofit/histfactory/benchHistFactory.cxx
+++ b/root/roofit/histfactory/benchHistFactory.cxx
@@ -23,18 +23,18 @@ public:
       using namespace RooFit;
 
       RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration hfCfg;
-      auto *w = TestWorkspaces::getWorkspace001(hfCfg);
+      std::unique_ptr<RooWorkspace> ws = TestWorkspaces::getWorkspace001(hfCfg);
 
-      auto *mc = static_cast<RooStats::ModelConfig *>(w->obj("ModelConfig"));
+      auto *mc = static_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));
 
       if (mc->GetParametersOfInterest())
          constraintParams.add(*mc->GetParametersOfInterest());
       if (mc->GetNuisanceParameters())
          constraintParams.add(*mc->GetNuisanceParameters());
 
-      auto *pdf = w->pdf("simPdf");
+      auto *pdf = ws->pdf("simPdf");
 
-      std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*w->data("obsData"), Constrain(constraintParams),
+      std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*ws->data("obsData"), Constrain(constraintParams),
                                                      GlobalObservables(*mc->GetGlobalObservables()), EvalBackend::Legacy())};
 
       RooMinimizer m(*nll);
@@ -64,14 +64,14 @@ static void benchHistFactory001(benchmark::State &state)
 
    RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration hfCfg;
    hfCfg.binnedFitOptimization = state.range(0);
-   auto *w = TestWorkspaces::getWorkspace001(hfCfg);
+   std::unique_ptr<RooWorkspace> ws = TestWorkspaces::getWorkspace001(hfCfg);
 
-   auto *mc = static_cast<RooStats::ModelConfig *>(w->obj("ModelConfig"));
+   auto *mc = static_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));
 
-   auto *pdf = w->pdf("simPdf");
+   auto *pdf = ws->pdf("simPdf");
 
    auto evalBackend = static_cast<EvalBackend::Value>(state.range(1));
-   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*w->data("obsData"), Constrain(g_testData.constraintParams),
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*ws->data("obsData"), Constrain(g_testData.constraintParams),
                                                   GlobalObservables(*mc->GetGlobalObservables()),
                                                   EvalBackend(evalBackend))};
 

--- a/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
+++ b/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
@@ -121,9 +121,7 @@ void buildBinnedTest(int n_channels = 1, int nbins = 10, int nnps = 1, const cha
    } else {
       ws = hist2workspace.MakeCombinedModel(meas);
    }
-   RooFIter iter = ws->components().fwdIterator();
-   RooAbsArg *arg;
-   while ((arg = iter.next())) {
+   for (RooAbsArg * arg : ws->components()) {
       if (arg->IsA() == RooRealSumPdf::Class()) {
          arg->setAttribute("BinnedLikelihood");
          if(verbose) std::cout << "component " << arg->GetName() << " is a binned likelihood" << std::endl;

--- a/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
+++ b/root/roofit/roofit/RooFitBinnedBenchmarks.cxx
@@ -115,11 +115,11 @@ void buildBinnedTest(int n_channels = 1, int nbins = 10, int nnps = 1, const cha
       meas.AddChannel(*chan);
    }
    HistoToWorkspaceFactoryFast hist2workspace(meas);
-   RooWorkspace *ws;
+   std::unique_ptr<RooWorkspace> ws;
    if (n_channels < 2) {
-      ws = hist2workspace.MakeSingleChannelModel(meas, *chan);
+      ws = std::unique_ptr<RooWorkspace>{hist2workspace.MakeSingleChannelModel(meas, *chan)};
    } else {
-      ws = hist2workspace.MakeCombinedModel(meas);
+      ws = std::unique_ptr<RooWorkspace>{hist2workspace.MakeCombinedModel(meas)};
    }
    for (RooAbsArg * arg : ws->components()) {
       if (arg->IsA() == RooRealSumPdf::Class()) {


### PR DESCRIPTION
Replace RooFit legacy iterators in `rootbench`, so that we can deprecate them at some point without causing warnings.