### PR TITLE
Remove unused using declaration from gen_h1

### DIFF
--- a/root/tree/tree/gen_h1.cxx
+++ b/root/tree/tree/gen_h1.cxx
@@ -27,7 +27,6 @@
 
 // Import classes from experimental namespace for the time being
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
-using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
 using RNTupleWriteOptions = ROOT::Experimental::RNTupleWriteOptions;
 


### PR DESCRIPTION
`RFieldBase` was moved out of the `Detail` namespace, but it's not actually used by the code.