### PR TITLE
Fixes for latest RNTuple changes

### DIFF
--- a/root/tree/dataframe/CMakeLists.txt
+++ b/root/tree/dataframe/CMakeLists.txt
@@ -63,7 +63,7 @@ if(rootbench-datafiles)
       RB_ADD_GBENCHMARK(RNTupleDSBenchmarks
          RNTupleDSBenchmarks.cxx
          LIBRARIES Core Hist RIO TreePlayer ROOTNTuple ROOTDataFrame
-         DOWNLOAD_DATAFILES B2HHH~none.ntuple
+         DOWNLOAD_DATAFILES B2HHH~none.rc2.ntuple
          LABEL short)
    endif()
 endif()

--- a/root/tree/dataframe/RNTupleDSBenchmarks.cxx
+++ b/root/tree/dataframe/RNTupleDSBenchmarks.cxx
@@ -58,10 +58,10 @@ auto Dataframe(DF &frame)
 
 static void BM_RNTupleDS_LHCB(benchmark::State &state)
 {
-   auto ntuple = ROOT::Experimental::RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto ntuple = ROOT::Experimental::RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.rc2.ntuple");
    const Long64_t nEntries = ntuple->GetNEntries() * (state.range(0) / 100.);
 
-   ROOT::RDataFrame df(RB::GetDataDir() + "/B2HHH~none.ntuple", "DecayTree");
+   ROOT::RDataFrame df(RB::GetDataDir() + "/B2HHH~none.rc2.ntuple", "DecayTree");
    auto df2 = df.Range(nEntries);
    auto h_ptr = Dataframe(df2);
    for (auto _ : state)

--- a/root/tree/dataframe/RNTupleDSBenchmarks.cxx
+++ b/root/tree/dataframe/RNTupleDSBenchmarks.cxx
@@ -1,5 +1,5 @@
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleDS.hxx>
+#include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RDataFrame.hxx>
 
 #include <benchmark/benchmark.h>
@@ -61,7 +61,7 @@ static void BM_RNTupleDS_LHCB(benchmark::State &state)
    auto ntuple = ROOT::Experimental::RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
    const Long64_t nEntries = ntuple->GetNEntries() * (state.range(0) / 100.);
 
-   auto df = ROOT::RDF::Experimental::FromRNTuple("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   ROOT::RDataFrame df(RB::GetDataDir() + "/B2HHH~none.ntuple", "DecayTree");
    auto df2 = df.Range(nEntries);
    auto h_ptr = Dataframe(df2);
    for (auto _ : state)

--- a/root/tree/tree/CMakeLists.txt
+++ b/root/tree/tree/CMakeLists.txt
@@ -37,5 +37,5 @@ if(ROOT_root7_FOUND AND rootbench-datafiles)
    RNTupleLHCBBenchmarks.cxx
    LABEL short
    LIBRARIES Core Hist MathCore RIO Tree ROOTNTuple
-   DOWNLOAD_DATAFILES B2HHH~none.ntuple)
+   DOWNLOAD_DATAFILES B2HHH~none.rc2.ntuple)
 endif(ROOT_root7_FOUND AND rootbench-datafiles)

--- a/root/tree/tree/RNTupleH1Benchmarks.cxx
+++ b/root/tree/tree/RNTupleH1Benchmarks.cxx
@@ -1,10 +1,7 @@
 #include <benchmark/benchmark.h>
 
 #include <ROOT/RDataFrame.hxx>
-#include <ROOT/RNTuple.hxx>
-#include <ROOT/RNTupleDS.hxx>
-#include <ROOT/RNTupleOptions.hxx>
-#include <ROOT/RNTupleView.hxx>
+#include <ROOT/RNTupleReader.hxx>
 
 #include <TCanvas.h>
 #include <TChain.h>
@@ -40,13 +37,13 @@ static void BM_RNTuple_H1(benchmark::State &state, const std::string &comprAlgor
    auto ipiView = ntuple->GetView<std::int32_t>("event.ipi");
    auto ipisView = ntuple->GetView<std::int32_t>("event.ipis");
    auto md0_dView = ntuple->GetView<float>("event.md0_d");
-   auto trackView = ntuple->GetViewCollection("event.tracks");
+   auto trackView = ntuple->GetCollectionView("event.tracks");
    auto nhitrpView = ntuple->GetView<std::int32_t>("event.tracks._0.nhitrp");
    auto rstartView = ntuple->GetView<float>("event.tracks._0.rstart");
    auto rendView = ntuple->GetView<float>("event.tracks._0.rend");
    auto nlhkView = ntuple->GetView<float>("event.tracks._0.nlhk");
    auto nlhpiView = ntuple->GetView<float>("event.tracks._0.nlhpi");
-   auto njetsView = ntuple->GetViewCollection("event.jets");
+   auto njetsView = ntuple->GetCollectionView("event.jets");
    // Check print info (minitest)
    std::ostringstream os;
    ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kSummary, os);

--- a/root/tree/tree/RNTupleLHCBBenchmarks.cxx
+++ b/root/tree/tree/RNTupleLHCBBenchmarks.cxx
@@ -22,7 +22,7 @@ static void BM_RNTuple_LHCB(benchmark::State &state)
 {
    using RNTupleReader = ROOT::Experimental::RNTupleReader;
 
-   auto ntuple = RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.ntuple");
+   auto ntuple = RNTupleReader::Open("DecayTree", RB::GetDataDir() + "/B2HHH~none.rc2.ntuple");
    auto viewH1IsMuon = ntuple->GetView<int>("H1_isMuon");
    auto viewH2IsMuon = ntuple->GetView<int>("H2_isMuon");
    auto viewH3IsMuon = ntuple->GetView<int>("H3_isMuon");

--- a/root/tree/tree/RNTupleLHCBBenchmarks.cxx
+++ b/root/tree/tree/RNTupleLHCBBenchmarks.cxx
@@ -1,4 +1,4 @@
-#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleReader.hxx>
 #include <TH1D.h>
 #include <benchmark/benchmark.h>
 #include <rootbench/RBConfig.h>

--- a/root/tree/tree/gen_h1.cxx
+++ b/root/tree/tree/gen_h1.cxx
@@ -1,7 +1,6 @@
-#include <ROOT/RField.hxx>
-#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RNTupleWriteOptions.hxx>
+#include <ROOT/RNTupleWriter.hxx>
 
 #include <TBranch.h>
 #include <TCanvas.h>


### PR DESCRIPTION
There is a new data file in the RNuple RC2 format available here:
https://cernbox.cern.ch/s/oMBJXfI0OHEpqy1

@dpiparo Could you copy the file to https://root.cern.ch/files/rootbench/