### PR TITLE
Adapt GenVector tests to use `size` instead of `Size` of SIMD type

### DIFF
--- a/root/math/genvector/RandomNumberEngine.h
+++ b/root/math/genvector/RandomNumberEngine.h
@@ -46,9 +46,9 @@ inline void SetSeed(int N)
 template <typename T>
 class TypeSize {
    template <typename C>
-   static constexpr size_t Get(decltype(&C::Size))
+   static constexpr size_t Get(decltype(&C::size))
    {
-      return C::Size;
+      return C::size();
    }
    template <typename C>
    static constexpr size_t Get(typename std::enable_if<std::is_arithmetic<C>::value>::type * = 0)


### PR DESCRIPTION
This makes the code compatible with `std::experimental::simd`. It's also entirely backwards compatible, because the old Vc type provided both `Size` and `size`.